### PR TITLE
Tag and Note Release workflow improvements

### DIFF
--- a/.github/workflows/Tag-And-Release.yml
+++ b/.github/workflows/Tag-And-Release.yml
@@ -67,7 +67,7 @@ jobs:
         if: steps.check-tag.outputs.exists != 'true'
         uses: ncipollo/release-action@bcfe5470707e8832e12347755757cec0eb3c22af # v1.18.0
         with: 
-          tag: ${{ steps.check-release.outputs.version }}
+          tag: ${{ steps.parse.outputs.version }}
           prerelease: true
           generateReleaseNotes: true
 

--- a/.github/workflows/Tag-And-Release.yml
+++ b/.github/workflows/Tag-And-Release.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check if tag exists remotely
-        id: tagcheck
+        id: check-tag
         run: |
           set -euo pipefail
           VERSION="${{ steps.parse.outputs.version }}"
@@ -57,14 +57,14 @@ jobs:
           fi
 
       - name: Create and push tag
-        if: steps.tagcheck.outputs.exists != 'true'
+        if: steps.check-tag.outputs.exists != 'true'
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0
         with:
           commit_message: version bump to ${{ steps.parse.outputs.version }}
           tagging_message: '${{ steps.parse.outputs.version }}'
 
       - name: Create GitHub Release
-        if: steps.tagcheck.outputs.exists != 'true'
+        if: steps.check-tag.outputs.exists != 'true'
         uses: ncipollo/release-action@bcfe5470707e8832e12347755757cec0eb3c22af # v1.18.0
         with: 
           tag: ${{ steps.check-release.outputs.version }}

--- a/.github/workflows/Tag-And-Release.yml
+++ b/.github/workflows/Tag-And-Release.yml
@@ -1,46 +1,109 @@
 name: Tag & Note Release
-on : 
-  pull_request:    
+
+on:
+  pull_request:
     branches:
       - main
     types:
       - closed
+
 permissions:
   contents: read
+
+concurrency:
+  group: tag-note-release-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
-  CheckRelease:
+  tag:
+    name: Create Tag & Release
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
     permissions:
-      contents: write # required for creating tags and releases
-    runs-on: macos-15
+      contents: write # required for creating tags and releases  
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
     steps:
-      - name: Check if merge is release branch
-        id: check-release
+      - name: Parse version from branch (release/x.y.z)
+        id: parse
         run: |
-          if [[ ${{ github.head_ref }} =~ ^release/([0-9]+\.[0-9]+\.[0-9]+$) ]]; then
-            echo "match=true" >> $GITHUB_OUTPUT
-            echo "version=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          REF="${{ github.event.pull_request.head.ref }}"
+          if [[ "$REF" =~ ^release/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Head branch must follow the format: release/x.y.z (got: $REF)"
+            exit 1
           fi
-      - name: Tag if release branch
-        if: github.event.pull_request.merged != true || steps.check-release.outputs.match != 'true'
-        run: exit 1
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Checkout merge commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
-          fetch-depth: '0'      
-      - uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
+          fetch-depth: 0
+
+      - name: Check if tag exists remotely
+        id: tagcheck
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.parse.outputs.version }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${VERSION} already exists on origin"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.tagcheck.outputs.exists != 'true'
+        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0
         with:
-          commit_message: version bump to ${{ steps.check-release.outputs.version }}
-          tagging_message: '${{ steps.check-release.outputs.version }}'
-      - uses: ncipollo/release-action@bcfe5470707e8832e12347755757cec0eb3c22af # v1.18.0
+          commit_message: version bump to ${{ steps.parse.outputs.version }}
+          tagging_message: '${{ steps.parse.outputs.version }}'
+
+      - name: Create GitHub Release
+        if: steps.tagcheck.outputs.exists != 'true'
+        uses: ncipollo/release-action@bcfe5470707e8832e12347755757cec0eb3c22af # v1.18.0
         with: 
           tag: ${{ steps.check-release.outputs.version }}
           prerelease: true
           generateReleaseNotes: true
-      - name: push cocoapods
-        env: 
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        id: cocoapod_trunk_push
+
+  cocoapods:
+    name: Push CocoaPods
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    needs: tag
+    runs-on: macos-15
+    permissions:
+      contents: read
+    env:
+      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      VERSION: ${{ needs.tag.outputs.version }}
+    steps:
+      - name: Checkout at tag
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ needs.tag.outputs.version }}
+          fetch-depth: 0
+
+      - name: Push OpenTelemetry-Swift-Api if not exists
         run: |
-          pod trunk push OpenTelemetry-Swift-Api.podspec --allow-warnings 
-          pod trunk push OpenTelemetry-Swift-Sdk.podspec --allow-warnings --synchronous
-        
+          set -euo pipefail
+          if pod trunk info OpenTelemetry-Swift-Api 2>&1 | grep -F " - ${VERSION} (" >/dev/null; then
+            echo "::warning::OpenTelemetry-Swift-Api '${VERSION}' already exists on CocoaPods. Skipping."
+          else
+            pod trunk push OpenTelemetry-Swift-Api.podspec --allow-warnings
+          fi
+      
+      - name: Push OpenTelemetry-Swift-Sdk if not exists
+        run: |
+          set -euo pipefail
+          if pod trunk info OpenTelemetry-Swift-Sdk 2>&1 | grep -F " - ${VERSION} (" >/dev/null; then
+            echo "::warning::OpenTelemetry-Swift-Sdk '${VERSION}' already exists on CocoaPods. Skipping."
+          else
+            pod trunk push OpenTelemetry-Swift-Sdk.podspec --allow-warnings --synchronous
+          fi


### PR DESCRIPTION
# Overview

This PR improves the `Tag & Note Release` workflow to make it more robust and readable.

## Changes
* Add a per-PR concurrency group to avoid overlapping runs for the same PR number and to cancel stale executions
* Ensure the workflow only runs when a PR is merged into main and the head branch follows release/x.y.z when the workflow begins. Previously, this was a step inside the job that would mark the whole job as a fail. Now they simply won’t run.
* Extract version number directly from the branch name (kept as before, but now centralized/explicit in one step).
* Check if a tag already exists before creating a new one, and skip CocoaPods publishing if the version is already on trunk. This makes the workflow idempotent: if a run fails (e.g. during `pod trunk push`), re running won't re tag or re release, but will retry CocoaPods publishing.
* Simplify job structure by splitting into two clear responsibilities: `tag` handles tagging (necessary for SPM) and release creation, while `cocoapods` only pushes pods. This makes the workflow more readable and maintainable.
