### PR TITLE
chore: mutate log records

### DIFF
--- a/Sources/OpenTelemetrySdk/Logs/Data/ReadableLogRecord.swift
+++ b/Sources/OpenTelemetrySdk/Logs/Data/ReadableLogRecord.swift
@@ -7,7 +7,7 @@ import Foundation
 import OpenTelemetryApi
 
 public struct ReadableLogRecord: Codable {
-  public init(resource: Resource, instrumentationScopeInfo: InstrumentationScopeInfo, timestamp: Date, observedTimestamp: Date? = nil, spanContext: SpanContext? = nil, severity: Severity? = nil, body: AttributeValue? = nil, attributes: [String: AttributeValue]) {
+  public init(resource: Resource, instrumentationScopeInfo: InstrumentationScopeInfo, timestamp: Date, observedTimestamp: Date? = nil, spanContext: SpanContext? = nil, severity: Severity? = nil, body: AttributeValue? = nil, attributes: [String: AttributeValue], eventName: String? = nil) {
     self.resource = resource
     self.instrumentationScopeInfo = instrumentationScopeInfo
     self.timestamp = timestamp
@@ -16,6 +16,7 @@ public struct ReadableLogRecord: Codable {
     self.severity = severity
     self.body = body
     self.attributes = attributes
+    self.eventName = eventName
   }
 
   public private(set) var resource: Resource
@@ -26,6 +27,7 @@ public struct ReadableLogRecord: Codable {
   public private(set) var severity: Severity?
   public private(set) var body: AttributeValue?
   public private(set) var attributes: [String: AttributeValue]
+  public private(set) var eventName: String?
 
   /// Puts a new attribute to the log record.
   /// - Parameters:

--- a/Sources/OpenTelemetrySdk/Logs/Data/ReadableLogRecord.swift
+++ b/Sources/OpenTelemetrySdk/Logs/Data/ReadableLogRecord.swift
@@ -26,4 +26,50 @@ public struct ReadableLogRecord: Codable {
   public private(set) var severity: Severity?
   public private(set) var body: AttributeValue?
   public private(set) var attributes: [String: AttributeValue]
+
+  /// Puts a new attribute to the log record.
+  /// - Parameters:
+  ///   - key: Key of the attribute.
+  ///   - value: Attribute value.
+  public mutating func setAttribute(key: String, value: AttributeValue?) {
+    if let value = value {
+      attributes[key] = value
+    } else {
+      attributes.removeValue(forKey: key)
+    }
+  }
+}
+
+public extension ReadableLogRecord {
+  mutating func setAttribute(key: String, value: String) {
+    setAttribute(key: key, value: AttributeValue.string(value))
+  }
+
+  mutating func setAttribute(key: String, value: Int) {
+    setAttribute(key: key, value: AttributeValue.int(value))
+  }
+
+  mutating func setAttribute(key: String, value: Double) {
+    setAttribute(key: key, value: AttributeValue.double(value))
+  }
+
+  mutating func setAttribute(key: String, value: Bool) {
+    setAttribute(key: key, value: AttributeValue.bool(value))
+  }
+
+  mutating func setAttribute(key: any RawRepresentable<String>, value: String) {
+    setAttribute(key: key.rawValue, value: AttributeValue.string(value))
+  }
+
+  mutating func setAttribute(key: any RawRepresentable<String>, value: Int) {
+    setAttribute(key: key.rawValue, value: AttributeValue.int(value))
+  }
+
+  mutating func setAttribute(key: any RawRepresentable<String>, value: Double) {
+    setAttribute(key: key.rawValue, value: AttributeValue.double(value))
+  }
+
+  mutating func setAttribute(key: any RawRepresentable<String>, value: Bool) {
+    setAttribute(key: key.rawValue, value: AttributeValue.bool(value))
+  }
 }

--- a/Tests/OpenTelemetrySdkTests/Logs/ReadableLogRecordTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Logs/ReadableLogRecordTests.swift
@@ -29,4 +29,41 @@ class ReadableLogRecordTests: XCTestCase {
     let key = logRecord?.attributes.keys.first
     XCTAssertEqual(logRecord?.attributes[key!]?.description.count, 1)
   }
+
+  func testSetAttribute() {
+    var logRecord = ReadableLogRecord(
+      resource: Resource(),
+      instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+      timestamp: Date(),
+      attributes: [:]
+    )
+
+    // Test string attribute
+    logRecord.setAttribute(key: "stringKey", value: "stringValue")
+    XCTAssertEqual(logRecord.attributes["stringKey"], AttributeValue.string("stringValue"))
+
+    // Test int attribute
+    logRecord.setAttribute(key: "intKey", value: 42)
+    XCTAssertEqual(logRecord.attributes["intKey"], AttributeValue.int(42))
+
+    // Test double attribute
+    logRecord.setAttribute(key: "doubleKey", value: 3.14)
+    XCTAssertEqual(logRecord.attributes["doubleKey"], AttributeValue.double(3.14))
+
+    // Test bool attribute
+    logRecord.setAttribute(key: "boolKey", value: true)
+    XCTAssertEqual(logRecord.attributes["boolKey"], AttributeValue.bool(true))
+
+    // Test AttributeValue attribute
+    logRecord.setAttribute(key: "attributeValueKey", value: AttributeValue.string("test"))
+    XCTAssertEqual(logRecord.attributes["attributeValueKey"], AttributeValue.string("test"))
+
+    // Test nil value removes attribute
+    logRecord.setAttribute(key: "stringKey", value: nil)
+    XCTAssertNil(logRecord.attributes["stringKey"])
+
+    // Test session.id attribute
+    logRecord.setAttribute(key: "session.id", value: "E6BD5A6F-076A-438C-9E6E-23DCF417F2F5")
+    XCTAssertEqual(logRecord.attributes["session.id"], AttributeValue.string("E6BD5A6F-076A-438C-9E6E-23DCF417F2F5"))
+  }
 }

--- a/Tests/OpenTelemetrySdkTests/Logs/ReadableLogRecordTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Logs/ReadableLogRecordTests.swift
@@ -66,4 +66,25 @@ class ReadableLogRecordTests: XCTestCase {
     logRecord.setAttribute(key: "session.id", value: "E6BD5A6F-076A-438C-9E6E-23DCF417F2F5")
     XCTAssertEqual(logRecord.attributes["session.id"], AttributeValue.string("E6BD5A6F-076A-438C-9E6E-23DCF417F2F5"))
   }
+
+  func testEventName() {
+    // Test with eventName
+    let logRecordWithEvent = ReadableLogRecord(
+      resource: Resource(),
+      instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+      timestamp: Date(),
+      attributes: [:],
+      eventName: "user.login"
+    )
+    XCTAssertEqual(logRecordWithEvent.eventName, "user.login")
+
+    // Test without eventName (default nil)
+    let logRecordWithoutEvent = ReadableLogRecord(
+      resource: Resource(),
+      instrumentationScopeInfo: InstrumentationScopeInfo(name: "test"),
+      timestamp: Date(),
+      attributes: [:]
+    )
+    XCTAssertNil(logRecordWithoutEvent.eventName)
+  }
 }


### PR DESCRIPTION
## Summary

This PR makes log record attributes mutable so that processors do not have to re-write them from scratch.

For example, SessionLogRecordProcessor rebuilds logs in order to add `session.id` - https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/Instrumentation/Sessions/SessionLogRecordProcessor.swift#L42

## Implementation

1. Add setAttribute method using Span.setAttribute method as reference
2. Add missing field eventName following log proto - https://github.com/open-telemetry/opentelemetry-proto/blob/v1.5.0/opentelemetry/proto/logs/v1/logs.proto#L226

Regarding (2), I will also have to update LogRecordAdapter in the other repo for this change to  be honored - https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/Exporters/OpenTelemetryProtocolCommon/logs/LogRecordAdapter.swift#L40


## Tests

Add unit tests