### PR TITLE
Add cancel handler to fix BatchSpanProcessor crash in long-running apps with offline caching enabled

### DIFF
--- a/Sources/OpenTelemetrySdk/Trace/SpanProcessors/BatchSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanProcessors/BatchSpanProcessor.swift
@@ -229,6 +229,10 @@ private class BatchWorker: WorkerThread {
     timeoutTimer.setEventHandler {
       exportOperation.cancel()
     }
+    timeoutTimer.setCancelHandler {
+      // Cancel handler ensures the dispatch source is properly deallocated
+      // and prevents double-release of the event handler block
+    }
 
     timeoutTimer.schedule(deadline: .now() + .milliseconds(Int(maxTimeOut.toMilliseconds)), leeway: .milliseconds(1))
     timeoutTimer.activate()


### PR DESCRIPTION
## Problem
I caught a BatchSpanProcessor crash with `EXC_BREAKPOINT (SIGTRAP)` in `_os_object_release_without_xref_dispose` after extended background operation. The crash occurs during dispatch source cleanup when cancelling the timeout timer in `exportBatch()`.

The `DispatchSource` timer lacks a cancel handler, causing libdispatch to follow an undefined cleanup path that results in double-release of the event handler block.

## Solution
Add `setCancelHandler` to the timeout timer. The handler can be empty—its presence ensures libdispatch uses the proper deallocation sequence during cancellation.
