### PR TITLE
Integrated OTel Bot for Release Automation

### DIFF
--- a/.github/workflows/Create-Release-PR.yml
+++ b/.github/workflows/Create-Release-PR.yml
@@ -36,11 +36,17 @@ jobs:
         sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Sdk.podspec
         sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-StdoutExporter.podspec
 
+    - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+      id: otelbot-token
+      with:
+        app-id: ${{ vars.OTELBOT_APP_ID }}
+        private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
       with:
-        token: ${{ secrets.RELEASE_TOKEN }}
+        token: ${{ steps.otelbot-token.outputs.token }}
+        branch-token: ${{ secrets.GITHUB_TOKEN }}
         branch: release/${{inputs.new_version}}
         commit-message: 'Release ${{inputs.new_version}}'
         title: 'Release ${{inputs.new_version}}'


### PR DESCRIPTION
# Overview
For more info on how this work, see [related documentation](https://github.com/open-telemetry/community/blob/main/assets.md#otelbot). 

To sum up: this change is necessary so we avoid using Github PAT.