### PR TITLE
feat(trace): support W3C random trace flag propagation

### DIFF
--- a/Sources/OpenTelemetryApi/Trace/TraceFlags.swift
+++ b/Sources/OpenTelemetryApi/Trace/TraceFlags.swift
@@ -13,6 +13,8 @@ public struct TraceFlags: Equatable, CustomStringConvertible, Codable, Sendable 
   private static let defaultOptions: UInt8 = 0
   /// Bit to represent whether trace is sampled or not.
   private static let isSampled: UInt8 = 0x1
+  // Bit to represent whether trace-id was generated with random procedure.
+  private static let isRandom: UInt8 = 0x2
 
   /// The size in bytes of the TraceFlags.
   static let size = 1
@@ -62,6 +64,11 @@ public struct TraceFlags: Equatable, CustomStringConvertible, Codable, Sendable 
     return options & TraceFlags.isSampled != 0
   }
 
+  /// A boolean indicating whether this Span's TraceId is known to be randomly generated.
+  public var random: Bool {
+    return options & TraceFlags.isRandom != 0
+  }
+
   /// Sets the sampling bit in the options.
   /// - Parameter isSampled: the sampling bit
   public mutating func setIsSampled(_ isSampled: Bool) {
@@ -83,7 +90,28 @@ public struct TraceFlags: Equatable, CustomStringConvertible, Codable, Sendable 
     return TraceFlags(fromByte: optionsCopy)
   }
 
+  /// Sets the random bit in the options.
+  /// - Parameter isRandom: the random bit
+  public mutating func setIsRandom(_ isRandom: Bool) {
+    if isRandom {
+      options = options | TraceFlags.isRandom
+    } else {
+      options = options & ~TraceFlags.isRandom
+    }
+  }
+
+  /// Sets the random bit in the options.
+  /// - Parameter isRandom: the random bit
+  public func settingIsRandom(_ isRandom: Bool) -> TraceFlags {
+    let optionsCopy: UInt8 = if isRandom {
+      options | TraceFlags.isRandom
+    } else {
+      options & ~TraceFlags.isRandom
+    }
+    return TraceFlags(fromByte: optionsCopy)
+  }
+
   public var description: String {
-    "TraceFlags{sampled=\(sampled)}"
+    "TraceFlags{sampled=\(sampled), random=\(random)}"
   }
 }

--- a/Tests/OpenTelemetryApiTests/Trace/TraceFlagsTests.swift
+++ b/Tests/OpenTelemetryApiTests/Trace/TraceFlagsTests.swift
@@ -25,6 +25,11 @@ final class TraceFlagsTests: XCTestCase {
     XCTAssertTrue(TraceFlags().settingIsSampled(true).sampled)
   }
 
+  func testIsRandom() {
+    XCTAssertFalse(TraceFlags().random)
+    XCTAssertTrue(TraceFlags().settingIsRandom(true).random)
+  }
+
   func testFromByte() {
     XCTAssertEqual(TraceFlags(fromByte: firstByte).byte, firstByte)
     XCTAssertEqual(TraceFlags(fromByte: secondByte).byte, secondByte)
@@ -39,6 +44,7 @@ final class TraceFlagsTests: XCTestCase {
 
   func testBuilder_FromOptions() {
     XCTAssertEqual(TraceFlags(fromByte: thirdByte).settingIsSampled(true).byte, 6 | 1)
+    XCTAssertEqual(TraceFlags(fromByte: thirdByte).settingIsRandom(true).byte, 6 | 2)
   }
 
   func testTraceFlags_EqualsAndHashCode() {
@@ -53,6 +59,8 @@ final class TraceFlagsTests: XCTestCase {
   func testTraceFlags_ToString() {
     XCTAssert(TraceFlags().description.contains("sampled=false"))
     XCTAssert(TraceFlags().settingIsSampled(true).description.contains("sampled=true"))
+    XCTAssert(TraceFlags().description.contains("random=false"))
+    XCTAssert(TraceFlags().settingIsRandom(true).description.contains("random=true"))
   }
 
   func testTraceFlags_Codabe() {


### PR DESCRIPTION
## Summary
- add support for the W3C trace-id random flag (0x02) in TraceFlags
- preserve the full trace-flags byte in W3CTraceContextPropagator inject/extract
- add regression tests for random-flag behavior in TraceFlagsTests and W3CTraceContextPropagatorTest

## Testing
- swift test --filter TraceFlagsTests
- swift test --filter W3CTraceContextPropagatorTest

Closes https://github.com/open-telemetry/opentelemetry-swift/issues/991