### PR TITLE
env var propagation carrier as Getter and Setter

### DIFF
--- a/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
@@ -88,7 +88,14 @@ public struct EnvironmentMappingGetter: Getter {
 
   public func get(carrier: [String: String], key: String) -> [String]? {
     let mappedKey = normalizeKeyForEnvironment(key)
-    return innerGetter.get(carrier: carrier, key: mappedKey)
+    if carrier[mappedKey] != nil {
+      return innerGetter.get(carrier: carrier, key: mappedKey)
+    }
+    let normalizedCarrier = Dictionary(
+      carrier.map { (normalizeKeyForEnvironment($0.key), $0.value) },
+      uniquingKeysWith: { first, _ in first }
+    )
+    return innerGetter.get(carrier: normalizedCarrier, key: mappedKey)
   }
 }
 

--- a/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
@@ -71,9 +71,9 @@ public struct EnvironmentMappingGetter: Getter {
 /// - Replaces every non-alphanumeric and non-underscore character with an underscore
 private func normalizeKeyForEnvironment(_ key: String) -> String {
   let normalized = key.uppercased()
-  return normalized.map { char in
+  return normalized.map { char -> String in
     if char.isLetter || char.isNumber || char == "_" {
-      return char
+      return String(char)
     } else {
       return "_"
     }

--- a/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
@@ -7,29 +7,75 @@ import Foundation
 import OpenTelemetryApi
 
 /**
- * Implementation of a EnvironmentContextPropagation propagation, using W3CTraceContextPropagator
+ * EnvironmentMappingSetter adapts a `Setter` to normalize W3C trace context keys to environment variable format.
+ *
+ * Normalization rules per OpenTelemetry specification:
+ * - Converts keys to uppercase (e.g., "traceparent" → "TRACEPARENT")
+ * - Replaces all non-alphanumeric characters (except underscore) with underscores
+ *   (e.g., "x-b3-traceid" → "X_B3_TRACEID")
+ *
+ * Usage:
+ * ```swift
+ * let innerSetter = MyCustomSetter()
+ * let envSetter = EnvironmentMappingSetter(innerSetter: innerSetter)
+ * w3cPropagator.inject(spanContext: context, carrier: &carrier, setter: envSetter)
+ * ```
+ *
+ * See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/env-carriers.md
  */
+public struct EnvironmentMappingSetter: Setter {
+  let innerSetter: any Setter
 
-public struct EnvironmentContextPropagator: TextMapPropagator {
-  static let traceParent = "TRACEPARENT"
-  static let traceState = "TRACESTATE"
-  let w3cPropagator = W3CTraceContextPropagator()
-
-  public let fields: Set<String> = [traceState, traceParent]
-
-  public init() {}
-
-  public func inject(spanContext: SpanContext, carrier: inout [String: String], setter: some Setter) {
-    var auxCarrier = [String: String]()
-    w3cPropagator.inject(spanContext: spanContext, carrier: &auxCarrier, setter: setter)
-    carrier[EnvironmentContextPropagator.traceParent] = auxCarrier["traceparent"]
-    carrier[EnvironmentContextPropagator.traceState] = auxCarrier["tracestate"]
+  public init(innerSetter: any Setter) {
+    self.innerSetter = innerSetter
   }
 
-  public func extract(carrier: [String: String], getter: some Getter) -> SpanContext? {
-    var auxCarrier = [String: String]()
-    auxCarrier["traceparent"] = carrier[EnvironmentContextPropagator.traceParent]
-    auxCarrier["tracestate"] = carrier[EnvironmentContextPropagator.traceState]
-    return w3cPropagator.extract(carrier: auxCarrier, getter: getter)
+  public func set(carrier: inout [String: String], key: String, value: String) {
+    let mappedKey = normalizeKeyForEnvironment(key)
+    innerSetter.set(carrier: &carrier, key: mappedKey, value: value)
   }
+}
+
+/**
+ * EnvironmentMappingGetter adapts a `Getter` to normalize W3C trace context keys to environment variable format.
+ *
+ * Normalization rules per OpenTelemetry specification:
+ * - Converts keys to uppercase (e.g., "traceparent" → "TRACEPARENT")
+ * - Replaces all non-alphanumeric characters (except underscore) with underscores
+ *   (e.g., "x-b3-traceid" → "X_B3_TRACEID")
+ *
+ * Usage:
+ * ```swift
+ * let innerGetter = EnvironmentVariableGetter()
+ * let envGetter = EnvironmentMappingGetter(innerGetter: innerGetter)
+ * let spanContext = w3cPropagator.extract(carrier: ProcessInfo.processInfo.environment, getter: envGetter)
+ * ```
+ *
+ * See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/env-carriers.md
+ */
+public struct EnvironmentMappingGetter: Getter {
+  let innerGetter: any Getter
+
+  public init(innerGetter: any Getter) {
+    self.innerGetter = innerGetter
+  }
+
+  public func get(carrier: [String: String], key: String) -> [String]? {
+    let mappedKey = normalizeKeyForEnvironment(key)
+    return innerGetter.get(carrier: carrier, key: mappedKey)
+  }
+}
+
+/// Normalizes a key for environment variable format:
+/// - Converts to uppercase
+/// - Replaces every non-alphanumeric and non-underscore character with an underscore
+private func normalizeKeyForEnvironment(_ key: String) -> String {
+  let normalized = key.uppercased()
+  return normalized.map { char in
+    if char.isLetter || char.isNumber || char == "_" {
+      return char
+    } else {
+      return "_"
+    }
+  }.joined()
 }

--- a/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
@@ -7,7 +7,7 @@ import Foundation
 import OpenTelemetryApi
 
 /**
- * EnvironmentMappingSetter adapts a `Setter` to normalize W3C trace context keys to environment variable format.
+ * EnvironmentMappingSetter adapts a `Setter` to normalize propagation keys to environment variable format.
  *
  * Normalization rules per OpenTelemetry specification:
  * - Converts keys to uppercase (e.g., "traceparent" → "TRACEPARENT")
@@ -21,7 +21,7 @@ import OpenTelemetryApi
  * w3cPropagator.inject(spanContext: context, carrier: &carrier, setter: envSetter)
  * ```
  *
- * See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/env-carriers.md
+ * See: https://opentelemetry.io/docs/specs/otel/context/env-carriers/
  */
 public struct EnvironmentMappingSetter: Setter {
   let innerSetter: any Setter
@@ -37,7 +37,7 @@ public struct EnvironmentMappingSetter: Setter {
 }
 
 /**
- * EnvironmentMappingGetter adapts a `Getter` to normalize W3C trace context keys to environment variable format.
+ * EnvironmentMappingGetter adapts a `Getter` to normalize propagation keys to environment variable format.
  *
  * Normalization rules per OpenTelemetry specification:
  * - Converts keys to uppercase (e.g., "traceparent" → "TRACEPARENT")
@@ -51,7 +51,7 @@ public struct EnvironmentMappingSetter: Setter {
  * let spanContext = w3cPropagator.extract(carrier: ProcessInfo.processInfo.environment, getter: envGetter)
  * ```
  *
- * See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/env-carriers.md
+ * See: https://opentelemetry.io/docs/specs/otel/context/env-carriers/
  */
 public struct EnvironmentMappingGetter: Getter {
   let innerGetter: any Getter

--- a/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
@@ -106,6 +106,10 @@ public struct EnvironmentMappingGetter: Getter {
 private func normalizeKeyForEnvironment(_ key: String) -> String {
   var result = ""
   result.reserveCapacity(key.utf8.count + 1)
+  // An env-var name must not start with a digit
+  if let first = key.unicodeScalars.first, (48...57).contains(first.value) {
+    result.append("_")
+  }
   for scalar in key.unicodeScalars {
     let v = scalar.value
     switch v {
@@ -118,10 +122,6 @@ private func normalizeKeyForEnvironment(_ key: String) -> String {
     default:                // anything else → _
       result.append("_")
     }
-  }
-  // An env-var name must not start with a digit
-  if let first = result.unicodeScalars.first, (48...57).contains(first.value) {
-    result.insert("_", at: result.startIndex)
   }
   return result
 }

--- a/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
@@ -119,7 +119,7 @@ private func normalizeKeyForEnvironment(_ key: String) -> String {
       result.append(Character(UnicodeScalar(v - 32)!))
     case 48...57, 95:       // 0–9 or _: keep as-is
       result.append(Character(scalar))
-    default:                // anything else → _
+    default:                // anything else: _
       result.append("_")
     }
   }

--- a/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
@@ -6,7 +6,9 @@
 import Foundation
 import OpenTelemetryApi
 
-
+/**
+ * Implementation of a EnvironmentContextPropagation propagation, using W3CTraceContextPropagator
+ */
 @available(*, deprecated, message: "Use EnvironmentMappingSetter or EnvironmentMappingGetter instead.")
 public struct EnvironmentContextPropagator: TextMapPropagator {
   static let traceParent = "TRACEPARENT"

--- a/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
@@ -6,6 +6,32 @@
 import Foundation
 import OpenTelemetryApi
 
+
+@available(*, deprecated, message: "Use EnvironmentMappingSetter or EnvironmentMappingGetter instead.")
+public struct EnvironmentContextPropagator: TextMapPropagator {
+  static let traceParent = "TRACEPARENT"
+  static let traceState = "TRACESTATE"
+  let w3cPropagator = W3CTraceContextPropagator()
+
+  public let fields: Set<String> = [traceState, traceParent]
+
+  public init() {}
+
+  public func inject(spanContext: SpanContext, carrier: inout [String: String], setter: some Setter) {
+    var auxCarrier = [String: String]()
+    w3cPropagator.inject(spanContext: spanContext, carrier: &auxCarrier, setter: setter)
+    carrier[EnvironmentContextPropagator.traceParent] = auxCarrier["traceparent"]
+    carrier[EnvironmentContextPropagator.traceState] = auxCarrier["tracestate"]
+  }
+
+  public func extract(carrier: [String: String], getter: some Getter) -> SpanContext? {
+    var auxCarrier = [String: String]()
+    auxCarrier["traceparent"] = carrier[EnvironmentContextPropagator.traceParent]
+    auxCarrier["tracestate"] = carrier[EnvironmentContextPropagator.traceState]
+    return w3cPropagator.extract(carrier: auxCarrier, getter: getter)
+  }
+}
+
 /**
  * EnvironmentMappingSetter adapts a `Setter` to normalize propagation keys to environment variable format.
  *

--- a/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
@@ -99,16 +99,29 @@ public struct EnvironmentMappingGetter: Getter {
   }
 }
 
-/// Normalizes a key for environment variable format:
-/// - Converts to uppercase
-/// - Replaces every non-alphanumeric and non-underscore character with an underscore
+/// Normalizes a key to environment-variable format:
+/// - Uppercases ASCII letters (`a–z` → `A–Z`)
+/// - Replaces every character that is not an ASCII letter, digit, or underscore with `_`
+/// - Prefixes the result with `_` if it would otherwise start with an ASCII digit
 private func normalizeKeyForEnvironment(_ key: String) -> String {
-  let normalized = key.uppercased()
-  return normalized.map { char -> String in
-    if char.isLetter || char.isNumber || char == "_" {
-      return String(char)
-    } else {
-      return "_"
+  var result = ""
+  result.reserveCapacity(key.utf8.count + 1)
+  for scalar in key.unicodeScalars {
+    let v = scalar.value
+    switch v {
+    case 65...90:           // A–Z: keep as-is
+      result.append(Character(scalar))
+    case 97...122:          // a–z: uppercase in-place
+      result.append(Character(UnicodeScalar(v - 32)!))
+    case 48...57, 95:       // 0–9 or _: keep as-is
+      result.append(Character(scalar))
+    default:                // anything else → _
+      result.append("_")
     }
-  }.joined()
+  }
+  // An env-var name must not start with a digit
+  if let first = result.unicodeScalars.first, (48...57).contains(first.value) {
+    result.insert("_", at: result.startIndex)
+  }
+  return result
 }

--- a/Sources/OpenTelemetrySdk/Trace/TracerSharedState.swift
+++ b/Sources/OpenTelemetrySdk/Trace/TracerSharedState.swift
@@ -43,8 +43,9 @@ class TracerSharedState {
 
     /// Recovers explicit parent context from process environment variables, it allows to automatic
     /// trace context propagation to child processes
-    let environmentPropagator = EnvironmentContextPropagator()
-    launchEnvironmentContext = environmentPropagator.extract(carrier: ProcessInfo.processInfo.environment, getter: EnvironmentGetter())
+    let w3cPropagator = W3CTraceContextPropagator()
+    let mappingGetter = EnvironmentMappingGetter(innerGetter: EnvironmentGetter())
+    launchEnvironmentContext = w3cPropagator.extract(carrier: ProcessInfo.processInfo.environment, getter: mappingGetter)
   }
 
   /// Adds a new SpanProcessor

--- a/Tests/OpenTelemetrySdkTests/Trace/EnvironmentContextPropagatorTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/EnvironmentContextPropagatorTests.swift
@@ -1,0 +1,136 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+import XCTest
+
+// Minimal Setter/Getter that store/retrieve values as-is, letting
+// EnvironmentMappingSetter / EnvironmentMappingGetter own all key transformation.
+private struct CapturingSetter: Setter {
+  func set(carrier: inout [String: String], key: String, value: String) {
+    carrier[key] = value
+  }
+}
+
+private struct CapturingGetter: Getter {
+  func get(carrier: [String: String], key: String) -> [String]? {
+    carrier[key].map { [$0] }
+  }
+}
+
+class EnvironmentContextPropagatorTests: XCTestCase {
+  private let setter = EnvironmentMappingSetter(innerSetter: CapturingSetter())
+  private let getter = EnvironmentMappingGetter(innerGetter: CapturingGetter())
+
+  // MARK: - EnvironmentMappingSetter key normalization
+
+  func testLowercaseLettersAreUppercased() {
+    var carrier = [String: String]()
+    setter.set(carrier: &carrier, key: "traceparent", value: "v")
+    XCTAssertEqual(carrier, ["TRACEPARENT": "v"])
+  }
+
+  func testUppercaseLettersArePreserved() {
+    var carrier = [String: String]()
+    setter.set(carrier: &carrier, key: "TRACEPARENT", value: "v")
+    XCTAssertEqual(carrier, ["TRACEPARENT": "v"])
+  }
+
+  func testMixedCaseIsUppercased() {
+    var carrier = [String: String]()
+    setter.set(carrier: &carrier, key: "traceParent", value: "v")
+    XCTAssertEqual(carrier, ["TRACEPARENT": "v"])
+  }
+
+  func testHyphenIsReplacedWithUnderscore() {
+    var carrier = [String: String]()
+    setter.set(carrier: &carrier, key: "x-b3-traceid", value: "v")
+    XCTAssertEqual(carrier, ["X_B3_TRACEID": "v"])
+  }
+
+  func testUnderscoreIsPreserved() {
+    var carrier = [String: String]()
+    setter.set(carrier: &carrier, key: "trace_id", value: "v")
+    XCTAssertEqual(carrier, ["TRACE_ID": "v"])
+  }
+
+  func testDigitInMiddleIsPreserved() {
+    var carrier = [String: String]()
+    setter.set(carrier: &carrier, key: "b3-123", value: "v")
+    XCTAssertEqual(carrier, ["B3_123": "v"])
+  }
+
+  func testLeadingDigitIsPrefixedWithUnderscore() {
+    var carrier = [String: String]()
+    setter.set(carrier: &carrier, key: "3foo", value: "v")
+    XCTAssertEqual(carrier, ["_3FOO": "v"])
+  }
+
+  func testLeadingDigitZeroIsPrefixedWithUnderscore() {
+    var carrier = [String: String]()
+    setter.set(carrier: &carrier, key: "0abc", value: "v")
+    XCTAssertEqual(carrier, ["_0ABC": "v"])
+  }
+
+  func testAllDigitsArePrefixedWithUnderscore() {
+    var carrier = [String: String]()
+    setter.set(carrier: &carrier, key: "123", value: "v")
+    XCTAssertEqual(carrier, ["_123": "v"])
+  }
+
+  func testSpecialCharactersAreReplacedWithUnderscore() {
+    var carrier = [String: String]()
+    setter.set(carrier: &carrier, key: "a.b:c/d", value: "v")
+    XCTAssertEqual(carrier, ["A_B_C_D": "v"])
+  }
+
+  func testNonAsciiLettersAreReplacedWithUnderscore() {
+    var carrier = [String: String]()
+    setter.set(carrier: &carrier, key: "héllo", value: "v")
+    XCTAssertEqual(carrier, ["H_LLO": "v"])
+
+    carrier.removeAll()
+    setter.set(carrier: &carrier, key: "über", value: "v")
+    XCTAssertEqual(carrier, ["_BER": "v"])
+  }
+
+  func testNonAsciiDigitsAreReplacedWithUnderscore() {
+    // ２ is a full-width digit (U+FF12); should become _
+    var carrier = [String: String]()
+    setter.set(carrier: &carrier, key: "２foo", value: "v")
+    XCTAssertEqual(carrier, ["_FOO": "v"])
+  }
+
+  func testEmptyStringProducesEmptyString() {
+    var carrier = [String: String]()
+    setter.set(carrier: &carrier, key: "", value: "v")
+    XCTAssertEqual(carrier, ["": "v"])
+  }
+
+  func testOnlySpecialCharacters() {
+    var carrier = [String: String]()
+    setter.set(carrier: &carrier, key: "---", value: "v")
+    XCTAssertEqual(carrier, ["___": "v"])
+  }
+
+  // MARK: - EnvironmentMappingGetter key normalization
+
+  func testGetterNormalizesLookupKey() {
+    let carrier = ["TRACEPARENT": "value"]
+    XCTAssertEqual(getter.get(carrier: carrier, key: "traceparent"), ["value"])
+  }
+
+  func testGetterNormalizesCarrierKeysWhenDirectLookupFails() {
+    // Carrier stored with lowercase; getter should normalize both sides and still find the value.
+    let carrier = ["traceparent": "value"]
+    XCTAssertEqual(getter.get(carrier: carrier, key: "traceparent"), ["value"])
+  }
+
+  func testGetterReturnsNilForMissingKey() {
+    let carrier = ["TRACEPARENT": "value"]
+    XCTAssertNil(getter.get(carrier: carrier, key: "tracestate"))
+  }
+}


### PR DESCRIPTION
Towards:
- https://github.com/open-telemetry/opentelemetry-specification/issues/5040

Per:
- https://github.com/open-telemetry/opentelemetry-specification/pull/4961#issuecomment-4085304690
- https://github.com/open-telemetry/opentelemetry-specification/pull/5003

This makes the environment variable propagation carrier to be composable with any propagator.

This should also make the implementation spec-compliant as I also implemented the key normalization.

Related to:
- https://github.com/open-telemetry/opentelemetry-specification/pull/4961
- https://github.com/open-telemetry/opentelemetry-specification/pull/4944

Disclaimer, I confess that I have never written a single line of code in Swift. I used Copilot and experience from other languages.