### PR TITLE
fix: resolve Swift 6.2 sending violations in ActivityContextManagerTests

### DIFF
--- a/Tests/OpenTelemetryApiTests/Context/ActivityContextManagerTests.swift
+++ b/Tests/OpenTelemetryApiTests/Context/ActivityContextManagerTests.swift
@@ -8,10 +8,6 @@
   import OpenTelemetryTestUtils
   import XCTest
 
-  #if compiler(>=5.10)
-  #warning("Sendable warnings suppressed for test compatibility")
-  #endif
-
   @MainActor
   class ActivityContextManagerTests: OpenTelemetryContextTestCase, @unchecked Sendable {
     override var contextManagers: [any ContextManager] {
@@ -162,7 +158,7 @@
     }
 
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
-    nonisolated func createAsyncSpan(parentSpan: Span?, name: String) async {
+    func createAsyncSpan(parentSpan: Span?, name: String) async {
       let activeSpan = ActivityContextManager.instance.getCurrentContextValue(forKey: .span)
       XCTAssert(activeSpan === parentSpan)
       let newSpan = defaultTracer.spanBuilder(spanName: name).startSpan()


### PR DESCRIPTION
## Summary

- Remove `nonisolated` from `createAsyncSpan` so it inherits `@MainActor` from the enclosing test class
- Remove outdated `#if compiler(>=5.10) #warning(...)` block

Swift 6.2 (Xcode 26) treats `sending` diagnostics as hard errors even with `-strict-concurrency=minimal`. The `nonisolated async func createAsyncSpan` caused 18 errors because passing non-`Sendable` `Span` values from `@MainActor` `Task` closures to a nonisolated async method crosses an isolation boundary. Removing `nonisolated` keeps the method on the main actor, eliminating the boundary.

## Test plan

- [x] `swift build --build-tests` — 0 errors (was 18)
- [x] `swift test` — 508 tests, 0 failures