### PR TITLE
fix(metrics): apply default view when no user view matches

### DIFF
--- a/Sources/OpenTelemetrySdk/Metrics/View/ViewRegistry.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/View/ViewRegistry.swift
@@ -32,7 +32,7 @@ public class ViewRegistry {
   }
 
   public func findViews(descriptor: InstrumentDescriptor, meterScope: InstrumentationScopeInfo) -> [RegisteredView] {
-    return registeredViews.filter { view in
+    let matches = registeredViews.filter { view in
       if let instrumentType = view.selector.instrumentType, descriptor.type != instrumentType {
         return false
       }
@@ -54,5 +54,9 @@ public class ViewRegistry {
 
       return true
     }
+    if matches.isEmpty, let fallback = instrumentDefaultRegisteredView[descriptor.type] {
+      return [fallback]
+    }
+    return matches
   }
 }

--- a/Tests/OpenTelemetrySdkTests/Metrics/MeterProviderSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/MeterProviderSdkTests.swift
@@ -13,4 +13,21 @@ class MeterProviderSdkTests: XCTestCase {
     XCTAssert(meterProvider.get(name: "test") as AnyObject === meterProvider.get(name: "test") as AnyObject)
     XCTAssert(meterProvider.get(name: "test") as AnyObject === meterProvider.meterBuilder(name: "test").build() as AnyObject)
   }
+
+  func testDefaultViewAppliedWhenNoViewsRegistered() {
+    let exporter = WaitingMetricExporter(numberToWaitFor: 1, aggregationTemporality: .delta)
+    let provider = MeterProviderSdk.builder()
+      .registerMetricReader(reader: PeriodicMetricReaderSdk(exporter: exporter, exportInterval: 60.0))
+      .build()
+    let meter = provider.meterBuilder(name: "default-view-test").build()
+    let histogram = meter.histogramBuilder(name: "test.latency_ms").build()
+    histogram.record(value: 42)
+    histogram.record(value: 17)
+
+    XCTAssertEqual(provider.forceFlush(), .success)
+    let metrics = exporter.waitForExport()
+    XCTAssertEqual(metrics.count, 1)
+    XCTAssertEqual(metrics.first?.name, "test.latency_ms")
+    XCTAssertEqual(metrics.first?.getHistogramData().first?.count, 2)
+  }
 }


### PR DESCRIPTION
Bug:
ViewRegistry.findViews never consulted instrumentDefaultRegisteredView, so with no user registered views every record silently dispatched to zero storages and nothing was exported.

Fix:
Fall back to the per instrument default view when no user view matches.

[Metrics SDK – Measurement processing](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#measurement-processing): If the MeterProvider has no View registered, take the Instrument and apply the default Aggregation on the basis of instrument kind according ...