### PR TITLE
Allow adding links after starting span

### DIFF
--- a/Sources/OpenTelemetryApi/Trace/PropagatedSpan.swift
+++ b/Sources/OpenTelemetryApi/Trace/PropagatedSpan.swift
@@ -95,6 +95,10 @@ class PropagatedSpan: Span {
 
   func addEvent(name: String, attributes: [String: AttributeValue], timestamp: Date) {}
 
+  func addLink(spanContext: SpanContext) {}
+
+  func addLink(spanContext: SpanContext, attributes: [String: AttributeValue]) {}
+
   func recordException(_ exception: SpanException) {}
 
   func recordException(_ exception: any SpanException, timestamp: Date) {}

--- a/Sources/OpenTelemetryApi/Trace/Span.swift
+++ b/Sources/OpenTelemetryApi/Trace/Span.swift
@@ -67,6 +67,16 @@ public protocol SpanBase: AnyObject, CustomStringConvertible {
   ///   - attributes: Dictionary of attributes name/value pairs associated with the event
   ///   - timestamp: the explicit event timestamp in nanos since epoch.
   func addEvent(name: String, attributes: [String: AttributeValue], timestamp: Date)
+
+  /// Adds a link to another span.
+  /// - Parameter spanContext: the context of the linked Span.
+  func addLink(spanContext: SpanContext)
+
+  /// Adds a link with attributes to another span.
+  /// - Parameters:
+  ///   - spanContext: the context of the linked Span.
+  ///   - attributes: attributes associated with the link.
+  func addLink(spanContext: SpanContext, attributes: [String: AttributeValue])
 }
 
 public protocol SpanExceptionRecorder {

--- a/Sources/OpenTelemetryApi/Trace/Span.swift
+++ b/Sources/OpenTelemetryApi/Trace/Span.swift
@@ -166,6 +166,12 @@ public extension SpanBase {
     return setAttribute(key: key.rawValue, value: AttributeValue.bool(value))
   }
 
+  func addLink(spanContext: SpanContext) {
+    addLink(spanContext: spanContext, attributes: [:])
+  }
+   
+  @available(*, deprecated, message: "add your own implmentation of addLink(spanContext:attributes:) instead of using this default implementation which does nothing, otherwise your links will not be recorded.")
+  func addLink(spanContext: SpanContext, attributes: [String: AttributeValue]) {}
 
 }
 

--- a/Sources/OpenTelemetrySdk/Trace/SpanSdk.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanSdk.swift
@@ -278,6 +278,29 @@ public class SpanSdk: ReadableSpan, @unchecked Sendable {
     addEvent(event: SpanData.Event(name: name, timestamp: timestamp, attributes: limitedAttributes.attributesCopy()))
   }
 
+  public func addLink(spanContext: SpanContext) {
+    addLink(SpanData.Link(context: spanContext))
+  }
+
+  public func addLink(spanContext: SpanContext, attributes: [String: AttributeValue]) {
+    addLink(SpanData.Link(context: spanContext, attributes: attributes))
+  }
+
+  public func addLink(_ link: SpanData.Link) {
+    lock.withWriterLock {
+      if !internalIsRecording {
+        return
+      }
+
+      totalRecordedLinks += 1
+      if links.count >= spanLimits.linkCountLimit {
+        return
+      }
+
+      links.append(link)
+    }
+  }
+
   private func addEvent(event: SpanData.Event) {
     lock.withWriterLock {
       if !internalIsRecording {

--- a/Tests/OpenTelemetrySdkTests/Trace/Mocks/ReadableSpanMock.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Mocks/ReadableSpanMock.swift
@@ -68,6 +68,10 @@ class ReadableSpanMock: ReadableSpan, @unchecked Sendable {
 
   func addEvent(name: String, attributes: [String: AttributeValue], timestamp: Date) {}
 
+  func addLink(spanContext: SpanContext) {}
+
+  func addLink(spanContext: SpanContext, attributes: [String: AttributeValue]) {}
+
   func recordException(_ exception: SpanException) {}
 
   func recordException(_ exception: any SpanException, timestamp: Date) {}

--- a/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanMock.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/Mocks/SpanMock.swift
@@ -41,6 +41,10 @@ class SpanMock: Span {
 
   func addEvent(name: String, attributes: [String: AttributeValue], timestamp: Date) {}
 
+  func addLink(spanContext: SpanContext) {}
+
+  func addLink(spanContext: SpanContext, attributes: [String: AttributeValue]) {}
+
   func recordException(_ exception: SpanException) {}
 
   func recordException(_ exception: any SpanException, timestamp: Date) {}

--- a/Tests/OpenTelemetrySdkTests/Trace/RecordEventsReadableSpanTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Trace/RecordEventsReadableSpanTests.swift
@@ -652,6 +652,42 @@ class SpanSdkTest: XCTestCase {
     XCTAssertEqual(expected, result)
   }
 
+  func testAddLinksAfterStart() {
+    let span = createTestRootSpan()
+    let addedContext = SpanContext.create(traceId: idGenerator.generateTraceId(),
+                                          spanId: idGenerator.generateSpanId(),
+                                          traceFlags: TraceFlags(),
+                                          traceState: TraceState())
+    let addedAttributes = TestUtils.generateRandomAttributes()
+
+    span.addLink(spanContext: addedContext)
+    span.addLink(spanContext: addedContext, attributes: addedAttributes)
+
+    let spanData = span.toSpanData()
+    XCTAssertEqual(spanData.links.count, 3)
+    XCTAssertEqual(spanData.totalRecordedLinks, 3)
+    XCTAssertEqual(spanData.links[1].context, addedContext)
+    XCTAssertEqual(spanData.links[1].attributes, [:])
+    XCTAssertEqual(spanData.links[2].context, addedContext)
+    XCTAssertEqual(spanData.links[2].attributes, addedAttributes)
+  }
+
+  func testAddLinksAfterStartRespectsLimit() {
+    let span = createTestSpan(config: SpanLimits().settingLinkCountLimit(2))
+    let addedContext = SpanContext.create(traceId: idGenerator.generateTraceId(),
+                                          spanId: idGenerator.generateSpanId(),
+                                          traceFlags: TraceFlags(),
+                                          traceState: TraceState())
+
+    span.addLink(spanContext: addedContext)
+    span.addLink(spanContext: addedContext)
+
+    let spanData = span.toSpanData()
+    XCTAssertEqual(spanData.links.count, 2)
+    XCTAssertEqual(spanData.totalRecordedLinks, 3)
+    XCTAssertEqual(span.getDroppedLinksCount(), 1)
+  }
+
   private func createTestRootSpan() -> SpanSdk {
     return createTestSpan(kind: .internal, config: SpanLimits(), parentContext: nil, attributes: [String: AttributeValue]())
   }


### PR DESCRIPTION
This relates to https://github.com/open-telemetry/opentelemetry-swift/pull/1063

In order to properly implement the protocol for a swift-distributed-tracing Instrument its expected that links can be added after a span has been created/started.

According to the spec this is allowed/not-forbidden https://github.com/open-telemetry/opentelemetry-swift/pull/1063#discussion_r3132324281

This adds the needed methods to allow this.