### PR TITLE
Update iOS destination architecture in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT_NAME="opentelemetry-swift-core-Package"
 
-IOS_DESTINATION ?= platform=iOS Simulator,name=iPhone 16
+IOS_DESTINATION ?= platform=iOS Simulator,name=iPhone 16,arch=arm64
 TVOS_DESTINATION ?= platform=tvOS Simulator,name=Apple TV 4K (3rd generation)
 WATCHOS_DESTINATION ?= platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)
 VISIONOS_DESTINATION ?= platform=visionOS Simulator,name=Apple Vision Pro


### PR DESCRIPTION
This should resolve test performance issues when the build system chooses an x86_64 simulator runs on arm64 macOS hardware due to : 
```
--- xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:iOS Simulator, arch:arm64, id:19BF4941-E297-412C-9BEF-5DDEBF0097A6, OS:26.2, name:iPhone 16 }
{ platform:iOS Simulator, arch:x86_64, id:19BF4941-E297-412C-9BEF-5DDEBF0097A6, OS:26.2, name:iPhone 16 }

```