### PR TITLE
Added CI Action to run pod spec lint on checks

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
+      should-lint-pods: ${{ steps.check.outputs.should-lint-pods }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -21,6 +22,7 @@ jobs:
         id: check
         run: |
           git diff --name-only origin/${{ github.base_ref }} HEAD | grep -q "Sources/" && echo "should-run=true" >> "$GITHUB_OUTPUT" || echo "should-run=false" >> "$GITHUB_OUTPUT"
+          git diff --name-only origin/${{ github.base_ref }} HEAD | grep -qE "(Sources/|\.podspec$)" && echo "should-lint-pods=true" >> "$GITHUB_OUTPUT" || echo "should-lint-pods=false" >> "$GITHUB_OUTPUT"
 
 
   FormattingLint: 
@@ -140,6 +142,21 @@ jobs:
       run: make build-for-testing-visionos VISIONOS_DESTINATION='${{ steps.visionos-sim.outputs.destination }}'
     - name: Test for visionOS
       run: make test-without-building-visionos VISIONOS_DESTINATION='${{ steps.visionos-sim.outputs.destination }}'
+  CocoaPodLint:
+    needs: should-run
+    if: ${{ needs.should-run.outputs.should-lint-pods == 'true' }}
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: 16.4
+      - name: Lint CocoaPods specs
+        run: |
+          pod lib lint OpenTelemetry-Swift-Api.podspec --allow-warnings
+          pod lib lint OpenTelemetry-Swift-Sdk.podspec --allow-warnings
+          pod lib lint OpenTelemetry-Swift-StdoutExporter.podspec --allow-warnings
+
   linux:
     needs: should-run
     if: ${{ needs.should-run.outputs.should-run == 'true' }}


### PR DESCRIPTION
# Overview
Adds a `CocoaPodLint` job to `BuildAndTest.yml` that runs `pod lib lint` against all three podspecs (`OpenTelemetry-Swift-Api`, `OpenTelemetry-Swift-Sdk` and`OpenTelemetry-Swift-StdoutExporter`) on every PR, catching CocoaPods validation failures early and not late, when they surface in the release pipeline.

> [!TIP]
> **Why `pod lib lint` instead of `pod spec lint`**
> During a PR there's no published tag yet, so `pod spec lint` (which fetches from the remote source) would fail for the wrong reasons. `pod lib lint` validates against local files (and has the option to include local podspecs) and surfaces the same class of issues that `pod trunk push` would catch at release time.

> [!NOTE]
> This job is intentionally left out of `required-status-checks` for now. Once we've confirmed it's stable and not flaky, the next step is to add `CocoaPodLint` to the `needs` ([source](https://github.com/open-telemetry/opentelemetry-swift-core/blob/7152009060aa0022475e64602f85e14212857bcc/.github/workflows/BuildAndTest.yml#L155)) list and the failure condition check in that job.

Solves #38 