### PR TITLE
Extract CocoaPods push into standalone reusable workflow

### DIFF
--- a/.github/workflows/Push-CocoaPods.yml
+++ b/.github/workflows/Push-CocoaPods.yml
@@ -1,0 +1,58 @@
+name: Push CocoaPods
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to push (e.g. 1.2.3)'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  cocoapods:
+    name: Push CocoaPods
+    runs-on: macos-15
+    env:
+      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Checkout at tag
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ inputs.version }}
+          fetch-depth: 0
+
+      - name: Push OpenTelemetry-Swift-Api if not exists
+        run: |
+          set -euo pipefail
+          if pod trunk info OpenTelemetry-Swift-Api 2>&1 | grep -F " - ${VERSION} (" >/dev/null; then
+            echo "::warning::OpenTelemetry-Swift-Api '${VERSION}' already exists on CocoaPods. Skipping."
+          else
+            pod trunk push OpenTelemetry-Swift-Api.podspec --allow-warnings
+          fi
+
+      - name: Push OpenTelemetry-Swift-Sdk if not exists
+        run: |
+          set -euo pipefail
+          if pod trunk info OpenTelemetry-Swift-Sdk 2>&1 | grep -F " - ${VERSION} (" >/dev/null; then
+            echo "::warning::OpenTelemetry-Swift-Sdk '${VERSION}' already exists on CocoaPods. Skipping."
+          else
+            pod trunk push OpenTelemetry-Swift-Sdk.podspec --allow-warnings --synchronous
+          fi
+
+      - name: Push OpenTelemetry-Swift-StdoutExporter if not exists
+        run: |
+          set -euo pipefail
+          if pod trunk info OpenTelemetry-Swift-StdoutExporter.podspec 2>&1 | grep -F " - ${VERSION} (" >/dev/null; then
+            echo "::warning::OpenTelemetry-Swift-StdoutExporter '${VERSION}' already exists on CocoaPods. Skipping."
+          else
+            pod trunk push OpenTelemetry-Swift-StdoutExporter.podspec --allow-warnings --synchronous
+          fi

--- a/.github/workflows/Tag-And-Release.yml
+++ b/.github/workflows/Tag-And-Release.yml
@@ -77,42 +77,7 @@ jobs:
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'release/')
     needs: tag
-    runs-on: macos-15
-    permissions:
-      contents: read
-    env:
-      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-      VERSION: ${{ needs.tag.outputs.version }}
-    steps:
-      - name: Checkout at tag
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          ref: ${{ needs.tag.outputs.version }}
-          fetch-depth: 0
-
-      - name: Push OpenTelemetry-Swift-Api if not exists
-        run: |
-          set -euo pipefail
-          if pod trunk info OpenTelemetry-Swift-Api 2>&1 | grep -F " - ${VERSION} (" >/dev/null; then
-            echo "::warning::OpenTelemetry-Swift-Api '${VERSION}' already exists on CocoaPods. Skipping."
-          else
-            pod trunk push OpenTelemetry-Swift-Api.podspec --allow-warnings
-          fi
-      
-      - name: Push OpenTelemetry-Swift-Sdk if not exists
-        run: |
-          set -euo pipefail
-          if pod trunk info OpenTelemetry-Swift-Sdk 2>&1 | grep -F " - ${VERSION} (" >/dev/null; then
-            echo "::warning::OpenTelemetry-Swift-Sdk '${VERSION}' already exists on CocoaPods. Skipping."
-          else
-            pod trunk push OpenTelemetry-Swift-Sdk.podspec --allow-warnings --synchronous
-          fi
-
-      - name: Push OpenTelemetry-Swift-StdoutExporter if not exists
-        run: |
-          set -euo pipefail
-          if pod trunk info OpenTelemetry-Swift-StdoutExporter.podspec 2>&1 | grep -F " - ${VERSION} (" >/dev/null; then
-            echo "::warning::OpenTelemetry-Swift-StdoutExporter '${VERSION}' already exists on CocoaPods. Skipping."
-          else
-            pod trunk push OpenTelemetry-Swift-StdoutExporter.podspec --allow-warnings --synchronous
-          fi
+    uses: ./.github/workflows/Push-CocoaPods.yml
+    with:
+      version: ${{ needs.tag.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
# Overview
The cocoapods release step has been extracted into its own reusable workflow (`Push-CocoaPods.yml`) that can be triggered both automatically (called from Tag-And-Release) and manually via `workflow_dispatch`. This allows re-running just the cocoapods push after fixing a transient failure (e.g. [`2.4.1` errors](https://github.com/open-telemetry/opentelemetry-swift-core/actions/runs/24200591178/job/70642850940)), without having to re-trigger the full release workflow or wait for a new PR merge.