### PR TITLE
Log a warning on duplicate instrument registration

### DIFF
--- a/Sources/OpenTelemetrySdk/Metrics/State/MetricStorageRegistry.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/State/MetricStorageRegistry.swift
@@ -27,20 +27,20 @@ public class MetricStorageRegistry {
     guard let storage = registry[descriptor] else {
       registry[descriptor] = newStorage
 
+      for existingStorage in registry.values {
+        if existingStorage as AnyObject === newStorage as AnyObject {
+          continue
+        }
+
+        let existing = existingStorage.metricDescriptor
+
+        if existing.name.lowercased() == descriptor.name.lowercased(), existing != descriptor {
+          OpenTelemetry.instance.feedbackHandler?("Found duplicate metric definition: \(descriptor.name). A metric with the same name but different identifying fields is already registered. To resolve, consider using a View to rename one of the instruments.")
+          break
+        }
+      }
+
       return newStorage
-    }
-
-    for storage in registry.values {
-      if storage as AnyObject === newStorage as AnyObject {
-        continue
-      }
-
-      let existing = storage.metricDescriptor
-
-      if existing.name.lowercased() == descriptor.name.lowercased(), existing != descriptor {
-        // todo: log warning
-        break
-      }
     }
 
     return storage

--- a/Tests/OpenTelemetrySdkTests/Metrics/MetricStorageRegistryTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/MetricStorageRegistryTests.swift
@@ -1,0 +1,46 @@
+//
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+import XCTest
+
+private class TestMetricStorage: MetricStorage {
+  let metricDescriptor: MetricDescriptor
+
+  init(name: String, description: String = "", unit: String = "") {
+    metricDescriptor = MetricDescriptor(name: name, description: description, unit: unit)
+  }
+
+  func collect(resource: Resource, scope: InstrumentationScopeInfo, startEpochNanos: UInt64, epochNanos: UInt64) -> MetricData {
+    return MetricData.empty
+  }
+
+  func isEmpty() -> Bool {
+    return true
+  }
+}
+
+class MetricStorageRegistryTests: XCTestCase {
+  func testRegisterReturnsExistingStorageForIdenticalDescriptor() {
+    let registry = MetricStorageRegistry()
+    let storage = TestMetricStorage(name: "counter")
+    let identical = TestMetricStorage(name: "counter")
+
+    XCTAssert(registry.register(newStorage: storage) as AnyObject === storage as AnyObject)
+    XCTAssert(registry.register(newStorage: identical) as AnyObject === storage as AnyObject)
+    XCTAssertEqual(registry.getStorages().count, 1)
+  }
+
+  func testRegisterKeepsConflictingStorages() {
+    let registry = MetricStorageRegistry()
+    let storage = TestMetricStorage(name: "counter", unit: "ms")
+    let conflicting = TestMetricStorage(name: "counter", unit: "s")
+
+    XCTAssert(registry.register(newStorage: storage) as AnyObject === storage as AnyObject)
+    XCTAssert(registry.register(newStorage: conflicting) as AnyObject === conflicting as AnyObject)
+    XCTAssertEqual(registry.getStorages().count, 2)
+  }
+}


### PR DESCRIPTION
Fixes open-telemetry/opentelemetry-swift#805

Logs a warning when an instrument is registered with the same name (case-insensitive) as an existing one but different identifying fields, with a hint to resolve the conflict with a View. The check now runs when the conflicting storage is registered, matching opentelemetry-java. Added registry tests.