### PR TITLE
Improve renovate docker handling

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,7 @@
   "packageRules": [
     {
       "groupName": "all patch versions",
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": ["patch", "digest"],
       "schedule": ["before 8am every weekday"]
     },
     {

--- a/.github/workflows/BackwardsCompatibility.yml
+++ b/.github/workflows/BackwardsCompatibility.yml
@@ -184,7 +184,7 @@ jobs:
   linux:
     needs: get-release
     runs-on: ubuntu-latest
-    container: swift:6.1@sha256:e4be69c365086d94715b08d53e391d0bb26d2f08ce0ae23358477f4fe0aadad9
+    container: swift:6.1.3@sha256:4c6af6663ed2316002a3b38ff5505a1fc1f2749ec31e84936c32dd336713c569
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -161,7 +161,7 @@ jobs:
     needs: should-run
     if: ${{ needs.should-run.outputs.should-run == 'true' }}
     runs-on: ubuntu-latest
-    container: swift:6.1@sha256:e4be69c365086d94715b08d53e391d0bb26d2f08ce0ae23358477f4fe0aadad9
+    container: swift:6.1.3@sha256:4c6af6663ed2316002a3b38ff5505a1fc1f2749ec31e84936c32dd336713c569
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Build tests for Linux


### PR DESCRIPTION
This improves how renovate handles docker updates as:

- digest updates treated the same as patches ie grouped as opposed to individual arriving anytime
- Docker images pinned to patch version where possible to provide insight on pr’s if it is major, minor etc

in the end this should result in less pr’s while not reducing time to raise other than by a few days in worst case for major/minor docker updates and few hours for digest updates.