### PR TITLE
Update ambiguous simulator selection

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -77,7 +77,7 @@ jobs:
       id: ios-sim
       run: |
         UDID=$(./Scripts/ci/resolve-simulator.sh iOS)
-        echo "destination=platform=iOS Simulator,id=$UDID" >> "$GITHUB_OUTPUT"
+        echo "destination=platform=iOS Simulator,id=$UDID,arch=arm64" >> "$GITHUB_OUTPUT"
     - name: Build for iOS
       run: make build-for-testing-ios IOS_DESTINATION='${{ steps.ios-sim.outputs.destination }}'
     - name: Test for iOS
@@ -97,7 +97,7 @@ jobs:
       id: tvos-sim
       run: |
         UDID=$(./Scripts/ci/resolve-simulator.sh tvOS)
-        echo "destination=platform=tvOS Simulator,id=$UDID" >> "$GITHUB_OUTPUT"
+        echo "destination=platform=tvOS Simulator,id=$UDID,arch=arm64" >> "$GITHUB_OUTPUT"
     - name: Build for tvOS
       run: make build-for-testing-tvos TVOS_DESTINATION='${{ steps.tvos-sim.outputs.destination }}'
     - name: Test for tvOS
@@ -117,7 +117,7 @@ jobs:
       id: watchos-sim
       run: |
         UDID=$(./Scripts/ci/resolve-simulator.sh watchOS)
-        echo "destination=platform=watchOS Simulator,id=$UDID" >> "$GITHUB_OUTPUT"
+        echo "destination=platform=watchOS Simulator,id=$UDID,arch=arm64" >> "$GITHUB_OUTPUT"
     - name: Build for watchOS
       run: make build-for-testing-watchos WATCHOS_DESTINATION='${{ steps.watchos-sim.outputs.destination }}'
     - name: Test for watchOS


### PR DESCRIPTION
`./Scripts/ci/resolve-simulator.sh` selects a simulator based of the id, but this still leads to ambiguity between  arm64 and x86_64 macOS runners: 
<img width="2886" height="370" alt="Screenshot 2026-06-29 155819" src="https://github.com/user-attachments/assets/55faa718-d375-4a62-bd42-11669a34a978" />
both variants have the same ID. This causes arbitrary selection and then severe performance issues in the tests if the wrong simulator architecture is selected. 
Since we are using `macos-15-arm64` we should be targeting the `arm64` simulators. This issue occurs for `iOS`, `tvOS`, and `watchOS` simulators. 