### PR TITLE
ci: update otelbot token workflows to use client IDs

### DIFF
--- a/.github/workflows/Create-Release-PR.yml
+++ b/.github/workflows/Create-Release-PR.yml
@@ -36,10 +36,10 @@ jobs:
         sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-Sdk.podspec
         sed -i -e  's/spec.version = ".*"/spec.version = "${{ inputs.new_version }}"/' OpenTelemetry-Swift-StdoutExporter.podspec
 
-    - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
-        app-id: ${{ vars.OTELBOT_APP_ID }}
+        client-id: ${{ vars.OTELBOT_CLIENT_ID }}
         private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
 
     - name: Create Pull Request


### PR DESCRIPTION
Update otelbot token creation to use GitHub App client IDs.

The `app-id` input for `actions/create-github-app-token` is deprecated in favor of `client-id`. The matching `OTELBOT_*_CLIENT_ID` organization variables have been provisioned, so this updates direct token creation from `app-id` / `*_APP_ID` to `client-id` / `*_CLIENT_ID`.

Tracking issue: https://github.com/open-telemetry/admin/issues/744