### PR TITLE
Add cancel handler to BatchLogRecordProcessor export timeout timer

### DIFF
--- a/Sources/OpenTelemetrySdk/Logs/Processors/BatchLogRecordProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Logs/Processors/BatchLogRecordProcessor.swift
@@ -160,6 +160,10 @@ private class BatchWorker: WorkerThread, @unchecked Sendable {
     }
     let timeoutTimer = DispatchSource.makeTimerSource(queue: DispatchQueue.global())
     timeoutTimer.setEventHandler { exportOperation.cancel() }
+    timeoutTimer.setCancelHandler {
+      // Cancel handler ensures the dispatch source is properly deallocated
+      // and prevents double-release of the event handler block
+    }
     let maxTimeOut = min(explicitTimeout ?? TimeInterval.greatestFiniteMagnitude, exportTimeout)
     timeoutTimer.schedule(deadline: .now() + .milliseconds(Int(maxTimeOut.toMilliseconds)), leeway: .milliseconds(1))
     timeoutTimer.activate()


### PR DESCRIPTION
### Summary

`BatchSpanProcessor.exportBatch` installs an empty `setCancelHandler` on its per-batch timeout timer so libdispatch takes a defined teardown path when the timer is cancelled — added in #17 with the comment *"prevents double-release of the event handler block"*.

`BatchLogRecordProcessor.exportBatch` builds the same `DispatchSource` timer, installs the same event handler, and cancels it the same way at the end of every batch — but never received the same cancel handler. So the log pipeline still has the bug the span pipeline was fixed for.

This applies the identical four-line change to the log processor.

### Why it matters

Cancelling an activated timer source whose event-handler block has no cancel handler double-releases that block. The heap damage is silent; the process keeps running and then faults inside `_xzm_xzone_malloc_*` at some later, unrelated allocation — so the crash report points at the victim rather than the cause, and is easy to misattribute to whatever code happened to allocate next.

It reproduces in the same conditions described in #17 — long-running apps with offline caching enabled — except more often on the log side, since `exportBatch` runs on every schedule tick for the life of the process rather than only when spans are flushed.

We hit this on iOS in a Kotlin Multiplatform app pinned to 2.3.0: crashes inside `_xzm_xzone_malloc_freelist_outlined`, clustered on the log-emit path because that is the busiest allocator in the same subsystem.

### Notes

- Behaviour is otherwise unchanged: the handler is intentionally empty, exactly as on the span side.
- No test added — same as #17, this is a libdispatch teardown contract that isn't observable from the SDK's public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)