### PR TITLE
Fix exponential histogram encoding

### DIFF
--- a/Sources/OpenTelemetrySdk/Metrics/Data/MetricData.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Data/MetricData.swift
@@ -86,9 +86,12 @@ public struct MetricData: Equatable, Codable, Sendable {
         .encode(data.points as! [LongPointData], forKey: .dataPoints)
     case .DoubleGauge, .DoubleSum:
       try container.encode(data.points as! [DoublePointData], forKey: .dataPoints)
-    case .Histogram, .ExponentialHistogram:
+    case .Histogram:
       try container
         .encode(data.points as! [HistogramPointData], forKey: .dataPoints)
+    case .ExponentialHistogram:
+      try container
+        .encode(data.points as! [ExponentialHistogramPointData], forKey: .dataPoints)
     }
 
     try container.encode(data.aggregationTemporality, forKey: .aggregationTemporality)
@@ -131,9 +134,18 @@ public struct MetricData: Equatable, Codable, Sendable {
         aggregationTemporality: aggregationTemporality,
         points: points
       )
-    case .Histogram, .ExponentialHistogram:
+    case .Histogram:
       let points = try container.decode(
         [HistogramPointData].self,
+        forKey: .dataPoints
+      )
+      data = Data(
+        aggregationTemporality: aggregationTemporality,
+        points: points
+      )
+    case .ExponentialHistogram:
+      let points = try container.decode(
+        [ExponentialHistogramPointData].self,
         forKey: .dataPoints
       )
       data = Data(

--- a/Tests/OpenTelemetrySdkTests/Metrics/Data/MetricDataTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/Data/MetricDataTests.swift
@@ -15,6 +15,8 @@ class MetricDataTests: XCTestCase {
   let emptyPointData = [PointData]()
   let unit = "unit"
 
+  // MARK: - Creation
+
   func testStableMetricDataCreation() {
     let type = MetricDataType.Summary
     let data = MetricData.Data(
@@ -162,66 +164,6 @@ class MetricDataTests: XCTestCase {
     XCTAssertEqual(histogramMetricData.zeroCount, 0)
   }
 
-  func testExponentialHistogramMetricDataCodable() {
-    let positiveBuckets = DoubleBase2ExponentialHistogramBuckets(scale: 20, maxBuckets: 160)
-    positiveBuckets.downscale(by: 20)
-    positiveBuckets.record(value: 10.0)
-    positiveBuckets.record(value: 40.0)
-    positiveBuckets.record(value: 90.0)
-    positiveBuckets.record(value: 100.0)
-
-    let negativeBuckets = DoubleBase2ExponentialHistogramBuckets(scale: 20, maxBuckets: 160)
-
-    let expHistogramPointData = ExponentialHistogramPointData(
-      scale: 20,
-      sum: 240.0,
-      zeroCount: 0,
-      hasMin: true,
-      hasMax: true,
-      min: 10.0,
-      max: 100.0,
-      positiveBuckets: positiveBuckets,
-      negativeBuckets: negativeBuckets,
-      startEpochNanos: 0,
-      epochNanos: 1,
-      attributes: [:],
-      exemplars: []
-    )
-
-    let metricData = MetricData.createExponentialHistogram(
-      resource: resource,
-      instrumentationScopeInfo: instrumentationScopeInfo,
-      name: metricName,
-      description: metricDescription,
-      unit: unit,
-      data: ExponentialHistogramData(
-        aggregationTemporality: .delta,
-        points: [expHistogramPointData]
-      )
-    )
-
-    do {
-      let encoded = try JSONEncoder().encode(metricData)
-      let decoded = try JSONDecoder().decode(MetricData.self, from: encoded)
-
-      assertCommon(decoded)
-      XCTAssertEqual(decoded.type, .ExponentialHistogram)
-      XCTAssertEqual(decoded.data.aggregationTemporality, .delta)
-      XCTAssertEqual(decoded.isMonotonic, false)
-      XCTAssertEqual(decoded.data.points.count, 1)
-
-      let point = try XCTUnwrap(decoded.data.points.first as? ExponentialHistogramPointData)
-      XCTAssertEqual(point.scale, 20)
-      XCTAssertEqual(point.sum, 240)
-      XCTAssertEqual(point.count, 4)
-      XCTAssertEqual(point.min, 10)
-      XCTAssertEqual(point.max, 100)
-      XCTAssertEqual(point.zeroCount, 0)
-    } catch {
-      XCTFail(String(describing: error))
-    }
-  }
-
   func testCreateDoubleGuage() {
     let type = MetricDataType.DoubleGauge
     let d = 22.22222
@@ -315,6 +257,8 @@ class MetricDataTests: XCTestCase {
     XCTAssertEqual(metricData.data.aggregationTemporality, .cumulative)
     XCTAssertEqual(metricData.isMonotonic, true)
   }
+
+  // MARK: - Codable
 
   func testLongGaugeMetricDataCodable() {
     let point = LongPointData(
@@ -480,6 +424,68 @@ class MetricDataTests: XCTestCase {
       XCTAssertEqual(decoded.isMonotonic, false)
     }
   }
+
+  func testExponentialHistogramMetricDataCodable() {
+    let positiveBuckets = DoubleBase2ExponentialHistogramBuckets(scale: 20, maxBuckets: 160)
+    positiveBuckets.downscale(by: 20)
+    positiveBuckets.record(value: 10.0)
+    positiveBuckets.record(value: 40.0)
+    positiveBuckets.record(value: 90.0)
+    positiveBuckets.record(value: 100.0)
+
+    let negativeBuckets = DoubleBase2ExponentialHistogramBuckets(scale: 20, maxBuckets: 160)
+
+    let expHistogramPointData = ExponentialHistogramPointData(
+      scale: 20,
+      sum: 240.0,
+      zeroCount: 0,
+      hasMin: true,
+      hasMax: true,
+      min: 10.0,
+      max: 100.0,
+      positiveBuckets: positiveBuckets,
+      negativeBuckets: negativeBuckets,
+      startEpochNanos: 0,
+      epochNanos: 1,
+      attributes: [:],
+      exemplars: []
+    )
+
+    let metricData = MetricData.createExponentialHistogram(
+      resource: resource,
+      instrumentationScopeInfo: instrumentationScopeInfo,
+      name: metricName,
+      description: metricDescription,
+      unit: unit,
+      data: ExponentialHistogramData(
+        aggregationTemporality: .delta,
+        points: [expHistogramPointData]
+      )
+    )
+
+    do {
+      let encoded = try JSONEncoder().encode(metricData)
+      let decoded = try JSONDecoder().decode(MetricData.self, from: encoded)
+
+      assertCommon(decoded)
+      XCTAssertEqual(decoded.type, .ExponentialHistogram)
+      XCTAssertEqual(decoded.data.aggregationTemporality, .delta)
+      XCTAssertEqual(decoded.isMonotonic, false)
+      XCTAssertEqual(decoded.data.points.count, 1)
+
+      let point = try XCTUnwrap(decoded.data.points.first as? ExponentialHistogramPointData)
+      XCTAssertEqual(point.scale, 20)
+      XCTAssertEqual(point.sum, 240)
+      XCTAssertEqual(point.count, 4)
+      XCTAssertEqual(point.min, 10)
+      XCTAssertEqual(point.max, 100)
+      XCTAssertEqual(point.zeroCount, 0)
+    } catch {
+      XCTFail(String(describing: error))
+    }
+  }
+
+  // MARK: - Helpers
 
   func assertCommon(_ metricData: MetricData) {
     XCTAssertEqual(metricData.resource, resource)

--- a/Tests/OpenTelemetrySdkTests/Metrics/Data/MetricDataTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/Data/MetricDataTests.swift
@@ -316,11 +316,194 @@ class MetricDataTests: XCTestCase {
     XCTAssertEqual(metricData.isMonotonic, true)
   }
 
+  func testLongGaugeMetricDataCodable() {
+    let point = LongPointData(
+      startEpochNanos: 0,
+      endEpochNanos: 1,
+      attributes: [:],
+      exemplars: [],
+      value: 33
+    )
+    let metricData = MetricData.createLongGauge(
+      resource: resource,
+      instrumentationScopeInfo: instrumentationScopeInfo,
+      name: metricName,
+      description: metricDescription,
+      unit: unit,
+      data: GaugeData(aggregationTemporality: .cumulative, points: [point])
+    )
+
+    assertMetricDataCodable(metricData) { decoded in
+      let decodedPoint = try XCTUnwrap(decoded.data.points.first as? LongPointData)
+      XCTAssertEqual(decodedPoint.value, 33)
+      XCTAssertEqual(decoded.isMonotonic, false)
+    }
+  }
+
+  func testLongSumMetricDataCodable() {
+    let point = LongPointData(
+      startEpochNanos: 0,
+      endEpochNanos: 1,
+      attributes: [:],
+      exemplars: [],
+      value: 55
+    )
+    let metricData = MetricData.createLongSum(
+      resource: resource,
+      instrumentationScopeInfo: instrumentationScopeInfo,
+      name: metricName,
+      description: metricDescription,
+      unit: unit,
+      isMonotonic: true,
+      data: SumData(aggregationTemporality: .cumulative, points: [point])
+    )
+
+    assertMetricDataCodable(metricData) { decoded in
+      let decodedPoint = try XCTUnwrap(decoded.data.points.first as? LongPointData)
+      XCTAssertEqual(decodedPoint.value, 55)
+      XCTAssertEqual(decoded.isMonotonic, true)
+    }
+  }
+
+  func testDoubleGaugeMetricDataCodable() {
+    let point = DoublePointData(
+      startEpochNanos: 0,
+      endEpochNanos: 1,
+      attributes: [:],
+      exemplars: [],
+      value: 22.22222
+    )
+    let metricData = MetricData.createDoubleGauge(
+      resource: resource,
+      instrumentationScopeInfo: instrumentationScopeInfo,
+      name: metricName,
+      description: metricDescription,
+      unit: unit,
+      data: GaugeData(aggregationTemporality: .cumulative, points: [point])
+    )
+
+    assertMetricDataCodable(metricData) { decoded in
+      let decodedPoint = try XCTUnwrap(decoded.data.points.first as? DoublePointData)
+      XCTAssertEqual(decodedPoint.value, 22.22222)
+      XCTAssertEqual(decoded.isMonotonic, false)
+    }
+  }
+
+  func testDoubleSumMetricDataCodable() {
+    let point = DoublePointData(
+      startEpochNanos: 0,
+      endEpochNanos: 1,
+      attributes: [:],
+      exemplars: [],
+      value: 44.4444
+    )
+    let metricData = MetricData.createDoubleSum(
+      resource: resource,
+      instrumentationScopeInfo: instrumentationScopeInfo,
+      name: metricName,
+      description: metricDescription,
+      unit: unit,
+      isMonotonic: true,
+      data: SumData(aggregationTemporality: .cumulative, points: [point])
+    )
+
+    assertMetricDataCodable(metricData) { decoded in
+      let decodedPoint = try XCTUnwrap(decoded.data.points.first as? DoublePointData)
+      XCTAssertEqual(decodedPoint.value, 44.4444)
+      XCTAssertEqual(decoded.isMonotonic, true)
+    }
+  }
+
+  func testSummaryMetricDataCodable() {
+    let point = SummaryPointData(
+      startEpochNanos: 0,
+      endEpochNanos: 1,
+      attributes: [:],
+      count: 100,
+      sum: 2.2,
+      percentileValues: [ValueAtQuantile(quantile: 1.1, value: 1.3)]
+    )
+    let metricData = MetricData(
+      resource: resource,
+      instrumentationScopeInfo: instrumentationScopeInfo,
+      name: metricName,
+      description: metricDescription,
+      unit: unit,
+      type: .Summary,
+      isMonotonic: false,
+      data: SummaryData(aggregationTemporality: .cumulative, points: [point])
+    )
+
+    assertMetricDataCodable(metricData) { decoded in
+      let decodedPoint = try XCTUnwrap(decoded.data.points.first as? SummaryPointData)
+      XCTAssertEqual(decodedPoint.count, 100)
+      XCTAssertEqual(decodedPoint.sum, 2.2)
+      XCTAssertEqual(decodedPoint.values.count, 1)
+      XCTAssertEqual(decodedPoint.values[0].quantile, 1.1)
+      XCTAssertEqual(decodedPoint.values[0].value, 1.3)
+      XCTAssertEqual(decoded.isMonotonic, false)
+    }
+  }
+
+  func testHistogramMetricDataCodable() {
+    let point = HistogramPointData(
+      startEpochNanos: 0,
+      endEpochNanos: 1,
+      attributes: [:],
+      exemplars: [],
+      sum: 10.0,
+      count: 4,
+      min: 1.0,
+      max: 4.0,
+      boundaries: [1.0, 2.0, 3.0],
+      counts: [1, 1, 1, 1],
+      hasMin: true,
+      hasMax: true
+    )
+    let metricData = MetricData.createHistogram(
+      resource: resource,
+      instrumentationScopeInfo: instrumentationScopeInfo,
+      name: metricName,
+      description: metricDescription,
+      unit: unit,
+      data: HistogramData(aggregationTemporality: .cumulative, points: [point])
+    )
+
+    assertMetricDataCodable(metricData) { decoded in
+      let decodedPoint = try XCTUnwrap(decoded.data.points.first as? HistogramPointData)
+      XCTAssertEqual(decodedPoint.sum, 10.0)
+      XCTAssertEqual(decodedPoint.count, 4)
+      XCTAssertEqual(decodedPoint.min, 1.0)
+      XCTAssertEqual(decodedPoint.max, 4.0)
+      XCTAssertEqual(decodedPoint.boundaries, [1.0, 2.0, 3.0])
+      XCTAssertEqual(decodedPoint.counts, [1, 1, 1, 1])
+      XCTAssertEqual(decoded.isMonotonic, false)
+    }
+  }
+
   func assertCommon(_ metricData: MetricData) {
     XCTAssertEqual(metricData.resource, resource)
     XCTAssertEqual(metricData.instrumentationScopeInfo, instrumentationScopeInfo)
     XCTAssertEqual(metricData.name, metricName)
     XCTAssertEqual(metricData.description, metricDescription)
     XCTAssertEqual(metricData.unit, unit)
+  }
+
+  private func assertMetricDataCodable(
+    _ metricData: MetricData,
+    verify: (MetricData) throws -> Void
+  ) {
+    do {
+      let encoded = try JSONEncoder().encode(metricData)
+      let decoded = try JSONDecoder().decode(MetricData.self, from: encoded)
+
+      assertCommon(decoded)
+      XCTAssertEqual(decoded.type, metricData.type)
+      XCTAssertEqual(decoded.data.aggregationTemporality, metricData.data.aggregationTemporality)
+      XCTAssertEqual(decoded.data.points.count, 1)
+      try verify(decoded)
+    } catch {
+      XCTFail(String(describing: error))
+    }
   }
 }

--- a/Tests/OpenTelemetrySdkTests/Metrics/Data/MetricDataTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/Data/MetricDataTests.swift
@@ -162,6 +162,66 @@ class MetricDataTests: XCTestCase {
     XCTAssertEqual(histogramMetricData.zeroCount, 0)
   }
 
+  func testExponentialHistogramMetricDataCodable() {
+    let positiveBuckets = DoubleBase2ExponentialHistogramBuckets(scale: 20, maxBuckets: 160)
+    positiveBuckets.downscale(by: 20)
+    positiveBuckets.record(value: 10.0)
+    positiveBuckets.record(value: 40.0)
+    positiveBuckets.record(value: 90.0)
+    positiveBuckets.record(value: 100.0)
+
+    let negativeBuckets = DoubleBase2ExponentialHistogramBuckets(scale: 20, maxBuckets: 160)
+
+    let expHistogramPointData = ExponentialHistogramPointData(
+      scale: 20,
+      sum: 240.0,
+      zeroCount: 0,
+      hasMin: true,
+      hasMax: true,
+      min: 10.0,
+      max: 100.0,
+      positiveBuckets: positiveBuckets,
+      negativeBuckets: negativeBuckets,
+      startEpochNanos: 0,
+      epochNanos: 1,
+      attributes: [:],
+      exemplars: []
+    )
+
+    let metricData = MetricData.createExponentialHistogram(
+      resource: resource,
+      instrumentationScopeInfo: instrumentationScopeInfo,
+      name: metricName,
+      description: metricDescription,
+      unit: unit,
+      data: ExponentialHistogramData(
+        aggregationTemporality: .delta,
+        points: [expHistogramPointData]
+      )
+    )
+
+    do {
+      let encoded = try JSONEncoder().encode(metricData)
+      let decoded = try JSONDecoder().decode(MetricData.self, from: encoded)
+
+      assertCommon(decoded)
+      XCTAssertEqual(decoded.type, .ExponentialHistogram)
+      XCTAssertEqual(decoded.data.aggregationTemporality, .delta)
+      XCTAssertEqual(decoded.isMonotonic, false)
+      XCTAssertEqual(decoded.data.points.count, 1)
+
+      let point = try XCTUnwrap(decoded.data.points.first as? ExponentialHistogramPointData)
+      XCTAssertEqual(point.scale, 20)
+      XCTAssertEqual(point.sum, 240)
+      XCTAssertEqual(point.count, 4)
+      XCTAssertEqual(point.min, 10)
+      XCTAssertEqual(point.max, 100)
+      XCTAssertEqual(point.zeroCount, 0)
+    } catch {
+      XCTFail(String(describing: error))
+    }
+  }
+
   func testCreateDoubleGuage() {
     let type = MetricDataType.DoubleGauge
     let d = 22.22222


### PR DESCRIPTION
## Summary

- `MetricData` Codable treated `.ExponentialHistogram` like `.Histogram` and force-cast points to `[HistogramPointData]`.
- Non-empty exponential histograms crash on encode (`Expected HistogramPointData but found ExponentialHistogramPointData`); decode would also fail because the coding shapes differ.
- Encode/decode now use `ExponentialHistogramPointData` for `.ExponentialHistogram`, with JSON round-trip coverage for every `MetricDataType`.


## Tests
Initially, I verified the bug with a test
https://github.com/open-telemetry/opentelemetry-swift-core/pull/99/changes/7de150e5a6e2456c235705104baab9ce86093615

<img width="1342" height="335" alt="Screenshot 2026-08-06 at 11 41 50" src="https://github.com/user-attachments/assets/e0405e94-de5d-4f97-9418-ce09eeaef984" />

And then, fixed the bug and added tests
- https://github.com/open-telemetry/opentelemetry-swift-core/pull/99/changes/bebb8273cb22927cca6e27fb23501779c0809a2e
- https://github.com/open-telemetry/opentelemetry-swift-core/pull/99/changes/db97d244e1997d597482505bc237c36d8a4c1415