### PR TITLE
Raise minimum OS versions to match opentelemetry-swift

### DIFF
--- a/Examples/ConcurrencyContext/main.swift
+++ b/Examples/ConcurrencyContext/main.swift
@@ -11,59 +11,55 @@
   let sampleKey = "sampleKey"
   let sampleValue = "sampleValue"
 
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   extension Task where Failure == Never, Success == Never {
     static func sleep(seconds: Double) async throws {
       try await sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
     }
   }
 
-  if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
-    // On Apple platforms, the default is the activity based context manager. We want to opt-in to the structured concurrency based context manager instead.
-    OpenTelemetry.registerDefaultConcurrencyContextManager()
-    
-    let stdout = StdoutSpanExporter()
-    OpenTelemetry.registerTracerProvider(
-      tracerProvider: TracerProviderBuilder().add(
-        spanProcessor: SimpleSpanProcessor(spanExporter: stdout)
-      ).build()
-    )
-    
-    let tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: "ConcurrencyContext", instrumentationVersion: "semver:0.1.0")
-    
-    func simpleSpan() async throws {
-      let span = tracer.spanBuilder(spanName: "SimpleSpan").setSpanKind(spanKind: .client).startSpan()
-      span.setAttribute(key: sampleKey, value: sampleValue)
-      try await Task.sleep(seconds: 0.5)
-      span.end()
-    }
+  // On Apple platforms, the default is the activity based context manager. We want to opt-in to the structured concurrency based context manager instead.
+  OpenTelemetry.registerDefaultConcurrencyContextManager()
 
-      
-    func childSpan() async throws {
-      // SpanBuilder's `setActive` method is not available here, since it isn't compatible with structured concurrency based context management
-      try await tracer.spanBuilder(spanName: "parentSpan").setSpanKind(spanKind: .client).withActiveSpan { @Sendable span in
-        span.setAttribute(key: sampleKey, value: sampleValue)
-        await Task.detached { @Sendable in
-          // A detached task doesn't inherit the task local context, so this span won't have a parent.
-          let notAChildSpan = tracer.spanBuilder(spanName: "notAChild").setSpanKind(spanKind: .client).startSpan()
-          notAChildSpan.setAttribute(key: sampleKey, value: sampleValue)
-          notAChildSpan.end()
-        }.value
-          
-        try await Task {
-          // Normal tasks should still inherit the context.
-          try await Task.sleep(seconds: 0.2)
-            let childSpan = tracer.spanBuilder(spanName: "childSpan").setSpanKind(spanKind: .client).startSpan()
-            childSpan.setAttribute(key: sampleKey, value: sampleValue)
-            try await Task.sleep(seconds: 0.5)
-            childSpan.end()
-          }.value
-      }
-    }
-      
-    try await simpleSpan()
-    try await Task.sleep(seconds: 1)
-    try await childSpan()
-    try await Task.sleep(seconds: 1)
+  let stdout = StdoutSpanExporter()
+  OpenTelemetry.registerTracerProvider(
+    tracerProvider: TracerProviderBuilder().add(
+      spanProcessor: SimpleSpanProcessor(spanExporter: stdout)
+    ).build()
+  )
+
+  let tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: "ConcurrencyContext", instrumentationVersion: "semver:0.1.0")
+
+  func simpleSpan() async throws {
+    let span = tracer.spanBuilder(spanName: "SimpleSpan").setSpanKind(spanKind: .client).startSpan()
+    span.setAttribute(key: sampleKey, value: sampleValue)
+    try await Task.sleep(seconds: 0.5)
+    span.end()
   }
+
+  func childSpan() async throws {
+    // SpanBuilder's `setActive` method is not available here, since it isn't compatible with structured concurrency based context management
+    try await tracer.spanBuilder(spanName: "parentSpan").setSpanKind(spanKind: .client).withActiveSpan { @Sendable span in
+      span.setAttribute(key: sampleKey, value: sampleValue)
+      await Task.detached { @Sendable in
+        // A detached task doesn't inherit the task local context, so this span won't have a parent.
+        let notAChildSpan = tracer.spanBuilder(spanName: "notAChild").setSpanKind(spanKind: .client).startSpan()
+        notAChildSpan.setAttribute(key: sampleKey, value: sampleValue)
+        notAChildSpan.end()
+      }.value
+
+      try await Task {
+        // Normal tasks should still inherit the context.
+        try await Task.sleep(seconds: 0.2)
+        let childSpan = tracer.spanBuilder(spanName: "childSpan").setSpanKind(spanKind: .client).startSpan()
+        childSpan.setAttribute(key: sampleKey, value: sampleValue)
+        try await Task.sleep(seconds: 0.5)
+        childSpan.end()
+      }.value
+    }
+  }
+
+  try await simpleSpan()
+  try await Task.sleep(seconds: 1)
+  try await childSpan()
+  try await Task.sleep(seconds: 1)
 #endif

--- a/OpenTelemetry-Swift-Api.podspec
+++ b/OpenTelemetry-Swift-Api.podspec
@@ -11,10 +11,10 @@ Pod::Spec.new do |spec|
   spec.source_files = "Sources/OpenTelemetryApi/**/*.swift"
 
   spec.swift_version = [ "6.0", "5.10" ]
-  spec.osx.deployment_target  = "10.13"
-  spec.ios.deployment_target = "12.0"
-  spec.tvos.deployment_target = "12.0"
-  spec.watchos.deployment_target = "4.0"
+  spec.osx.deployment_target  = "12.0"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
   spec.visionos.deployment_target = "1.0"
   spec.module_name = "OpenTelemetryApi"
   # This is necessary because we use the `package` keyword to access some properties in `OpenTelemetryApi`

--- a/OpenTelemetry-Swift-Sdk.podspec
+++ b/OpenTelemetry-Swift-Sdk.podspec
@@ -12,10 +12,10 @@ Pod::Spec.new do |spec|
   spec.source_files = "Sources/OpenTelemetrySdk/**/*.swift"
 
   spec.swift_version = [ "6.0", "5.10" ]
-  spec.osx.deployment_target  = "10.13"
-  spec.ios.deployment_target = "12.0"
-  spec.tvos.deployment_target = "12.0"
-  spec.watchos.deployment_target = "4.0"
+  spec.osx.deployment_target  = "12.0"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
   spec.visionos.deployment_target = "1.0"
   spec.module_name = "OpenTelemetrySdk"
   spec.dependency 'OpenTelemetry-Swift-Api', spec.version.to_s

--- a/OpenTelemetry-Swift-StdoutExporter.podspec
+++ b/OpenTelemetry-Swift-StdoutExporter.podspec
@@ -12,10 +12,10 @@ Pod::Spec.new do |spec|
   spec.source_files = "Sources/Exporters/Stdout/*.swift"
 
   spec.swift_version = [ "6.0", "5.10" ]
-  spec.osx.deployment_target  = "10.13"
-  spec.ios.deployment_target = "12.0"
-  spec.tvos.deployment_target = "12.0"
-  spec.watchos.deployment_target = "4.0"
+  spec.osx.deployment_target  = "12.0"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
   spec.visionos.deployment_target = "1.0"
   spec.module_name = "StdoutExporter"
 

--- a/Package.swift
+++ b/Package.swift
@@ -7,10 +7,10 @@ import PackageDescription
 let package = Package(
   name: "opentelemetry-swift-core",
   platforms: [
-    .macOS(.v10_13),
-    .iOS(.v12),
-    .tvOS(.v12),
-    .watchOS(.v4),
+    .macOS(.v12),
+    .iOS(.v13),
+    .tvOS(.v13),
+    .watchOS(.v6),
     .visionOS(.v1),
   ],
   products: [
@@ -52,7 +52,7 @@ let package = Package(
       name: "OpenTelemetryApiTests",
       dependencies: ["OpenTelemetryApi", "OpenTelemetryTestUtils"],
       path: "Tests/OpenTelemetryApiTests",
-      swiftSettings: [.unsafeFlags(["-Xfrontend", "-disable-availability-checking", "-strict-concurrency=minimal"])]
+      swiftSettings: [.unsafeFlags(["-strict-concurrency=minimal"])]
     ),
     .testTarget(
       name: "OpenTelemetrySdkTests",
@@ -62,7 +62,6 @@ let package = Package(
         "OpenTelemetryTestUtils",
       ],
       path: "Tests/OpenTelemetrySdkTests",
-      swiftSettings: [.unsafeFlags(["-Xfrontend", "-disable-availability-checking"])]
     ),
     .executableTarget(
       name: "ConcurrencyContext",

--- a/Sources/OpenTelemetryApi/Context/ContextManager.swift
+++ b/Sources/OpenTelemetryApi/Context/ContextManager.swift
@@ -18,7 +18,6 @@ public protocol ContextManager: AnyObject {
     /// Updates the current context value with the given key for the duration of the passed closure.
     /// If `value` is non-`nil` the key is set to that value.
     /// If `value` is `nil` the key is removed from the current context for the duration of the closure.
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withCurrentContextValue<T>(forKey: OpenTelemetryContextKeys, value: AnyObject?, _ operation: () async throws -> T) async rethrows -> T
   #endif
 }
@@ -28,7 +27,6 @@ public protocol ContextManager: AnyObject {
 public protocol ImperativeContextManager: ContextManager {}
 
 public extension ContextManager where Self: ImperativeContextManager {
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func withCurrentContextValue<T>(forKey key: OpenTelemetryContextKeys, value: AnyObject?, _ operation: () async throws -> T) async rethrows -> T {
     var oldValue: AnyObject?
     if let value {

--- a/Sources/OpenTelemetryApi/Context/OpenTelemetryContextProvider.swift
+++ b/Sources/OpenTelemetryApi/Context/OpenTelemetryContextProvider.swift
@@ -59,12 +59,10 @@ public struct OpenTelemetryContextProvider {
     /// Sets `span` as the active span for the duration of the given closure.
     /// While the span will no longer be active after the closure exits, this method does **not** end the span.
     /// Prefer `SpanBuilderBase.withActiveSpan` which handles starting, activating, and ending the span.
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     public func withActiveSpan<T>(_ span: SpanBase, _ operation: () async throws -> T) async rethrows -> T {
       try await contextManager.withCurrentContextValue(forKey: .span, value: span, operation)
     }
 
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     public func withActiveBaggage<T>(_ span: Baggage, _ operation: () async throws -> T) async rethrows -> T {
       try await contextManager.withCurrentContextValue(forKey: .baggage, value: span, operation)
     }

--- a/Sources/OpenTelemetryApi/Context/TaskLocalContextManager.swift
+++ b/Sources/OpenTelemetryApi/Context/TaskLocalContextManager.swift
@@ -8,7 +8,6 @@ import Foundation
 #if canImport(_Concurrency)
   @preconcurrency import _Concurrency
   
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   struct SendableWrapper: @unchecked Sendable {
     let value: AnyObject?
   }
@@ -21,7 +20,6 @@ import Foundation
   ///
   /// - Note: This restriction means this class is not suitable for dynamic context injection.
   /// If you require dynamic context injection, you will need a custom context manager.
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   public final class TaskLocalContextManager: ContextManager, @unchecked Sendable {
     package static let instance = TaskLocalContextManager()
 

--- a/Sources/OpenTelemetryApi/Trace/PropagatedSpanBuilder.swift
+++ b/Sources/OpenTelemetryApi/Trace/PropagatedSpanBuilder.swift
@@ -76,7 +76,6 @@ class PropagatedSpanBuilder: SpanBuilder {
   }
 
   #if canImport(_Concurrency)
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withActiveSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T {
       let span = startSpan()
       defer {

--- a/Sources/OpenTelemetryApi/Trace/SpanBuilder.swift
+++ b/Sources/OpenTelemetryApi/Trace/SpanBuilder.swift
@@ -110,7 +110,6 @@ public protocol SpanBuilderBase: AnyObject {
 
   #if canImport(_Concurrency)
     /// Starts a new Span and makes it active for the duration of the passed closure. The span will be ended before this method returns.
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withActiveSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T
   #endif
 
@@ -126,7 +125,6 @@ public protocol SpanBuilderBase: AnyObject {
 
   #if canImport(_Concurrency)
     /// Starts a new Span. The span will be ended before this method returns.
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withStartedSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T
   #endif
 }
@@ -148,7 +146,6 @@ public extension SpanBuilderBase {
   }
 
   #if canImport(_Concurrency)
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withStartedSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T {
       let span = startSpan()
       defer {

--- a/Sources/OpenTelemetryConcurrency/OpenTelemetry.swift
+++ b/Sources/OpenTelemetryConcurrency/OpenTelemetry.swift
@@ -52,7 +52,6 @@ public struct TracerProviderWrapper: @unchecked Sendable {
 /// // This typealias will be preferred over the name in either package, so you only have to refer to the module name once
 /// typealias OpenTelemetry = OpenTelemetryConcurrency.OpenTelemetry
 /// ```
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct OpenTelemetry: Sendable {
   public static var version: String { _OpenTelemetry.version }
 
@@ -117,7 +116,6 @@ public struct OpenTelemetry: Sendable {
   }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct OpenTelemetryContextProvider: @unchecked Sendable {
   var contextManager: ContextManager
 

--- a/Sources/OpenTelemetrySdk/Logs/Export/LogRecordExporter.swift
+++ b/Sources/OpenTelemetrySdk/Logs/Export/LogRecordExporter.swift
@@ -16,13 +16,10 @@ public protocol LogRecordExporter: Sendable {
   ///
   func forceFlush(explicitTimeout: TimeInterval?) -> ExportResult
 
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval?) async -> ExportResult
 
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func shutdown(explicitTimeout: TimeInterval?) async
 
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func forceFlush(explicitTimeout: TimeInterval?) async -> ExportResult
 }
 
@@ -40,7 +37,6 @@ public extension LogRecordExporter {
   }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public extension LogRecordExporter {
   func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval?) async -> ExportResult {
     assertionFailure("async export(logRecords:explicitTimeout:) must be implemented by \(type(of: self))")

--- a/Sources/OpenTelemetrySdk/Logs/Export/MultiLogRecordExporter.swift
+++ b/Sources/OpenTelemetrySdk/Logs/Export/MultiLogRecordExporter.swift
@@ -35,7 +35,6 @@ public final class MultiLogRecordExporter: LogRecordExporter {
   }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension MultiLogRecordExporter {
   public func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval? = nil) async -> ExportResult {
     await withTaskGroup(of: ExportResult.self, returning: ExportResult.self) { group in

--- a/Sources/OpenTelemetrySdk/Metrics/Exporter/MetricExporter.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Exporter/MetricExporter.swift
@@ -13,13 +13,10 @@ public protocol MetricExporter: AggregationTemporalitySelectorProtocol, DefaultA
   func flush() -> ExportResult
   func shutdown() -> ExportResult
 
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func export(metrics: [MetricData]) async -> ExportResult
 
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func flush() async -> ExportResult
 
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func shutdown() async -> ExportResult
 }
 
@@ -29,7 +26,6 @@ public extension MetricExporter {
   }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public extension MetricExporter {
   func export(metrics: [MetricData]) async -> ExportResult {
     assertionFailure("async export(metrics:) must be implemented by \(type(of: self))")

--- a/Sources/OpenTelemetrySdk/Trace/Export/MultiSpanExporter.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Export/MultiSpanExporter.swift
@@ -39,7 +39,6 @@ public final class MultiSpanExporter: SpanExporter {
   }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension MultiSpanExporter {
   public func export(spans: [SpanData], explicitTimeout: TimeInterval? = nil) async -> SpanExporterResultCode {
     await withTaskGroup(of: SpanExporterResultCode.self, returning: SpanExporterResultCode.self) { group in

--- a/Sources/OpenTelemetrySdk/Trace/Export/SpanExporter.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Export/SpanExporter.swift
@@ -21,13 +21,10 @@ public protocol SpanExporter: AnyObject, Sendable {
   ///  to a TracerSdkFactory object.
   func shutdown(explicitTimeout: TimeInterval?)
 
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   @discardableResult func export(spans: [SpanData], explicitTimeout: TimeInterval?) async -> SpanExporterResultCode
 
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func flush(explicitTimeout: TimeInterval?) async -> SpanExporterResultCode
 
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func shutdown(explicitTimeout: TimeInterval?) async
 }
 
@@ -45,7 +42,6 @@ public extension SpanExporter {
   }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public extension SpanExporter {
   @discardableResult func export(spans: [SpanData], explicitTimeout: TimeInterval?) async -> SpanExporterResultCode {
     assertionFailure("async export(spans:explicitTimeout:) must be implemented by \(type(of: self))")

--- a/Sources/OpenTelemetrySdk/Trace/SpanBuilderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanBuilderSdk.swift
@@ -173,7 +173,6 @@ class SpanBuilderSdk: SpanBuilder {
   }
 
   #if canImport(_Concurrency)
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     public func withActiveSpan<T>(_ operation: (any SpanBase) async throws -> T) async rethrows -> T {
       let createdSpan = prepareSpan()
       defer {

--- a/Sources/OpenTelemetryTestUtils/OpenTelemetryTestCase.swift
+++ b/Sources/OpenTelemetryTestUtils/OpenTelemetryTestCase.swift
@@ -73,9 +73,7 @@ open class OpenTelemetryContextTestCase: XCTestCase {
   public static func concurrencyContextManagers() -> [ContextManager] {
     var managers = [ContextManager]()
     #if canImport(_Concurrency)
-      if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
-        managers.append(TaskLocalContextManager.instance)
-      }
+      managers.append(TaskLocalContextManager.instance)
     #endif
     return managers
   }
@@ -87,9 +85,7 @@ open class OpenTelemetryContextTestCase: XCTestCase {
       managers.append(ActivityContextManager.instance)
     #endif
     #if canImport(_Concurrency)
-      if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
-        managers.append(TaskLocalContextManager.instance)
-      }
+      managers.append(TaskLocalContextManager.instance)
     #endif
     return managers
   }

--- a/Tests/OpenTelemetryApiTests/Baggage/DefaultBaggageManagerTests.swift
+++ b/Tests/OpenTelemetryApiTests/Baggage/DefaultBaggageManagerTests.swift
@@ -60,7 +60,6 @@ class DefaultBaggageManagerTests: DefaultBaggageManagerTestsInfo, @unchecked Sen
 }
 
 #if canImport(_Concurrency)
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   class DefaultBaggageManagerConcurrency: DefaultBaggageManagerTestsInfo, @unchecked Sendable {
     override var contextManagers: [any ContextManager] {
       Self.concurrencyContextManagers()

--- a/Tests/OpenTelemetryApiTests/Context/ActivityContextManagerTests.swift
+++ b/Tests/OpenTelemetryApiTests/Context/ActivityContextManagerTests.swift
@@ -100,7 +100,6 @@
       XCTAssertEqual(parentSpan.context.traceId, child2.context.traceId)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func testStartAndEndSpanInAsyncTask() {
       let span1 = defaultTracer.spanBuilder(spanName: "testStartAndEndSpanInAsyncTask").startSpan()
       ActivityContextManager.instance.setCurrentContextValue(forKey: .span, value: span1)
@@ -116,7 +115,6 @@
       XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func testStartAndEndSpanInAsyncTaskAsync() async {
       let span1 = defaultTracer.spanBuilder(spanName: "testStartAndEndSpanInAsyncTask").startSpan()
       ActivityContextManager.instance.setCurrentContextValue(forKey: .span, value: span1)
@@ -128,7 +126,6 @@
       XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func testStartAndEndSpanInAsyncTaskTwice() {
       let span1 = defaultTracer.spanBuilder(spanName: "testStartAndEndSpanInAsyncTaskTwice1").startSpan()
       ActivityContextManager.instance.setCurrentContextValue(forKey: .span, value: span1)
@@ -145,7 +142,6 @@
       XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func testStartAndEndSpanInAsyncTaskTwiceAsync() async {
       let span1 = defaultTracer.spanBuilder(spanName: "testStartAndEndSpanInAsyncTaskTwice1").startSpan()
       ActivityContextManager.instance.setCurrentContextValue(forKey: .span, value: span1)
@@ -157,7 +153,6 @@
       XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func createAsyncSpan(parentSpan: Span?, name: String) async {
       let activeSpan = ActivityContextManager.instance.getCurrentContextValue(forKey: .span)
       XCTAssert(activeSpan === parentSpan)
@@ -166,7 +161,6 @@
       endSpanAndValidateContext(span: newSpan, parentSpan: parentSpan)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func testStartAndEndSpanInAsyncTaskAnidated() {
       let span1 = defaultTracer.spanBuilder(spanName: "testStartAndEndSpanInAsyncTaskAnidated1").startSpan()
       ActivityContextManager.instance.setCurrentContextValue(forKey: .span, value: span1)
@@ -182,7 +176,6 @@
       XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func testStartAndEndSpanInAsyncTaskAnidatedAsync() async {
       let span1 = defaultTracer.spanBuilder(spanName: "testStartAndEndSpanInAsyncTaskAnidated1").startSpan()
       ActivityContextManager.instance.setCurrentContextValue(forKey: .span, value: span1)
@@ -193,7 +186,6 @@
       XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func createAsyncSpanOutside(parentSpan: Span) async {
       let activeSpan = ActivityContextManager.instance.getCurrentContextValue(forKey: .span)
       XCTAssert(activeSpan === parentSpan)
@@ -203,7 +195,6 @@
       endSpanAndValidateContext(span: newSpan, parentSpan: parentSpan)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func createAsyncSpanInside(parentSpan: Span) async {
       let activeSpan = ActivityContextManager.instance.getCurrentContextValue(forKey: .span)
       XCTAssert(activeSpan === parentSpan)
@@ -213,7 +204,6 @@
       endSpanAndValidateContext(span: newSpan, parentSpan: parentSpan)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     // First created task correctly does not inherit activity when created detached
     func testStartAndEndSpanInAsyncTaskDetachedWithParent() {
       let span1 = defaultTracer.spanBuilder(spanName: "testStartAndEndSpanInAsyncTask1").startSpan()
@@ -230,7 +220,6 @@
       waitForExpectations(timeout: 30)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     // First created task correctly does not inherit activity when created detached
     func testStartAndEndSpanInAsyncTaskDetachedWithParentAsync() async {
       let span1 = defaultTracer.spanBuilder(spanName: "testStartAndEndSpanInAsyncTask1").startSpan()
@@ -247,7 +236,6 @@
       await fulfillment(of: [expec], timeout: 30)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     // First created task correctly inherits activity when created, so assigns the proper parent
     func testStartAndEndSpanInAsyncTaskWithParent() {
       let span1 = defaultTracer.spanBuilder(spanName: "testStartAndEndSpanInAsyncTask1").startSpan()
@@ -264,7 +252,6 @@
       XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     // First created task correctly inherits activity when created, so assigns the proper parent
     func testStartAndEndSpanInAsyncTaskWithParentAsync() async {
       let span1 = defaultTracer.spanBuilder(spanName: "testStartAndEndSpanInAsyncTask1").startSpan()
@@ -281,7 +268,6 @@
       XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func testActiveSpanIsKeptPerTask() {
       let expectation1 = expectation(description: "firstSpan created")
       let expectation2 = expectation(description: "secondSpan created")
@@ -310,7 +296,6 @@
       XCTAssert(OpenTelemetry.instance.contextProvider.activeSpan === nil)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func testRemoveContextValuesFromSpan() {
       // Create a span
       let span1 = defaultTracer.spanBuilder(spanName: "span1").startSpan()
@@ -349,7 +334,6 @@
       XCTAssert(ActivityContextManager.instance.getCurrentContextValue(forKey: .span) === nil)
     }
 
-    @available(macOS 10.15, iOS 13.0, tvOS 13.0, *)
     func testActiveSpanIsKeptPerTaskAsync() async {
       let expectation1 = expectation(description: "firstSpan created")
       let expectation2 = expectation(description: "secondSpan created")


### PR DESCRIPTION
## Summary

- Raise package and CocoaPods minimum deployment targets to macOS 12, iOS 13, tvOS 13, watchOS 6 (matching opentelemetry-swift).
- Remove redundant `@available` / `#available` gates on Swift Concurrency APIs now covered by the package minimums.
- Drop `-disable-availability-checking` from test targets in Package.swift.

## Test plan

- [x] `swift build --build-tests`
- [x] `swift test` (560 tests passed)
- [ ] CI (BuildAndTest workflow)

<details>
<summary>Breaking change</summary>

Drops support for macOS 10.13–11, iOS 12, tvOS 12, and watchOS 4–5.
</details>

Made with [Cursor](https://cursor.com)