### PR TITLE
chore: add .editorconfig for 2-space indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# editorconfig.org
+#
+# Xcode 16+ reads this file automatically when opening Package.swift.
+# Ensure Settings → Text Editing → Indentation → "Prefer Settings from EditorConfig" is on.
+# If indentation looks wrong after checkout, quit and reopen Xcode.
+#
+# Matches .swiftformat (--indent 2).
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary
- Add root `.editorconfig` so Xcode 16+ and other editors default to 2-space indentation.
- Matches existing `.swiftformat` (`--indent 2`) settings.
- Includes a Makefile exception (tabs required for recipes) and inline Xcode usage notes.

## Test plan
- [x] Open `Package.swift` in Xcode 16+ — indentation shows 2 spaces
- [x] Confirm Tab inserts 2 spaces in a Swift file