### PR TITLE
Bump watchOS minimum required version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     .macOS(.v10_13),
     .iOS(.v12),
     .tvOS(.v12),
-    .watchOS(.v4),
+    .watchOS(.v9),
     .visionOS(.v1),
   ],
   products: [


### PR DESCRIPTION
Update watchOS requirement to 9.0, which is Xcode 27's lowest supported version.
<img width="641" height="182" alt="Screenshot 2026-08-25 at 12 14 47 PM" src="https://github.com/user-attachments/assets/bb8dd400-139c-4fd5-b115-6890da44d9b5" />
