### PR TITLE
feat(metrics): export periodic metrics on a background queue

### DIFF
--- a/Sources/OpenTelemetrySdk/Metrics/Exporter/PeriodicMeterReaderBuilder.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Exporter/PeriodicMeterReaderBuilder.swift
@@ -11,6 +11,7 @@ public typealias StablePeriodicMetricReaderBuilder = PeriodicMetricReaderBuilder
 public class PeriodicMetricReaderBuilder {
   public private(set) var exporter: MetricExporter
   public private(set) var exporterInterval: TimeInterval = 1.0
+  public private(set) var exportTimeout: TimeInterval = 30.0
 
   public init(exporter: MetricExporter) {
     self.exporter = exporter
@@ -21,8 +22,14 @@ public class PeriodicMetricReaderBuilder {
     return self
   }
 
+  public func setExportTimeout(timeInterval: TimeInterval) -> Self {
+    exportTimeout = timeInterval
+    return self
+  }
+
   public func build() -> PeriodicMetricReaderSdk {
     return PeriodicMetricReaderSdk(exporter: exporter,
-                                         exportInterval: exporterInterval)
+                                         exportInterval: exporterInterval,
+                                         exportTimeout: exportTimeout)
   }
 }

--- a/Sources/OpenTelemetrySdk/Metrics/Exporter/PeriodicMetricReaderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Exporter/PeriodicMetricReaderSdk.swift
@@ -12,16 +12,28 @@ public typealias StablePeriodicMetricReaderSdk = PeriodicMetricReaderSdk
 public final class PeriodicMetricReaderSdk: MetricReader, @unchecked Sendable {
   let exporter: MetricExporter
   let exportInterval: TimeInterval
-  let scheduleQueue = DispatchQueue(label: "org.opentelemetry.StablePeriodicMetricReaderSdk.scheduleQueue")
-  let exportQueue = DispatchQueue(label: "org.opentelemetry.StablePeriodicMetricReaderSdk.exportQueue",
+  let exportTimeout: TimeInterval
+  let scheduleQueue = DispatchQueue(label: "org.opentelemetry.PeriodicMetricReaderSdk.scheduleQueue")
+  // Uses `DispatchQoS.userInitiated` to match callers that sync-wait (forceFlush/shutdown) to avoid priority inversion.
+  let exportQueue = DispatchQueue(label: "org.opentelemetry.PeriodicMetricReaderSdk.exportQueue",
                                   qos: .userInitiated)
+  let exportOperationQueue: OperationQueue
   let scheduleTimer: DispatchSourceTimer
   let metricProduce: ReadWriteLocked<MetricProducer> = .init(initialValue: NoopMetricProducer())
   private let hasShutdown = Locked(initialValue: false)
 
-  init(exporter: MetricExporter, exportInterval: TimeInterval = 60.0) {
+  init(exporter: MetricExporter, exportInterval: TimeInterval = 60.0, exportTimeout: TimeInterval = 30.0) {
     self.exporter = exporter
     self.exportInterval = exportInterval
+    if exportTimeout >= 0 {
+      self.exportTimeout = exportTimeout
+    } else {
+      print("exportTimeout (\(exportTimeout)) < 0, fallback to default 30.")
+      self.exportTimeout = 30
+    }
+    exportOperationQueue = OperationQueue()
+    exportOperationQueue.name = "org.opentelemetry.PeriodicMetricReaderSdk.exportOperationQueue"
+    exportOperationQueue.maxConcurrentOperationCount = 1
     scheduleTimer = DispatchSource.makeTimerSource(flags: DispatchSource.TimerFlags(), queue: scheduleQueue)
 
     scheduleTimer.setEventHandler { [weak self] in
@@ -50,9 +62,17 @@ public final class PeriodicMetricReaderSdk: MetricReader, @unchecked Sendable {
   }
 
   public func forceFlush() -> ExportResult {
-    exportQueue.sync {
-      collectAndExport()
+    let result = Locked(initialValue: ExportResult.failure)
+    let group = DispatchGroup()
+    group.enter()
+    exportQueue.async { [self] in
+      result.locking { $0 = collectAndExport() }
+      group.leave()
     }
+    guard group.wait(timeout: .now() + exportTimeout) != .timedOut else {
+      return .failure
+    }
+    return result.locking { $0 }
   }
 
   private func enqueueExport() {
@@ -71,7 +91,25 @@ public final class PeriodicMetricReaderSdk: MetricReader, @unchecked Sendable {
     if metricData.isEmpty {
       return .success
     }
-    return exporter.export(metrics: metricData)
+    return exportMetricsWithTimeout(metricData, timeout: exportTimeout)
+  }
+
+  private func exportMetricsWithTimeout(_ metrics: [MetricData], timeout: TimeInterval) -> ExportResult {
+    let result = Locked(initialValue: ExportResult.failure)
+    let exportOperation = BlockOperation { [exporter] in
+      result.locking { $0 = exporter.export(metrics: metrics) }
+    }
+    let timeoutTimer = DispatchSource.makeTimerSource(queue: DispatchQueue.global())
+    timeoutTimer.setEventHandler { exportOperation.cancel() }
+    timeoutTimer.schedule(deadline: .now() + .milliseconds(Int(timeout.toMilliseconds)), leeway: .milliseconds(1))
+    timeoutTimer.activate()
+    exportOperationQueue.addOperation(exportOperation)
+    exportOperationQueue.waitUntilAllOperationsAreFinished()
+    timeoutTimer.cancel()
+    if exportOperation.isCancelled {
+      return .failure
+    }
+    return result.locking { $0 }
   }
 
   public func shutdown() -> ExportResult {
@@ -91,8 +129,15 @@ public final class PeriodicMetricReaderSdk: MetricReader, @unchecked Sendable {
       scheduleTimer.cancel()
       scheduleTimer.resume()
     }
-    exportQueue.sync {}
-    return exporter.shutdown()
+    // Wait for in-flight/queued exports before shutting down the exporter.
+    let group = DispatchGroup()
+    group.enter()
+    exportQueue.async {
+      group.leave()
+    }
+    let drainedInTime = group.wait(timeout: .now() + exportTimeout) != .timedOut
+    let shutdownResult = exporter.shutdown()
+    return drainedInTime && shutdownResult == .success ? .success : .failure
   }
 
   public func getAggregationTemporality(for instrument: InstrumentType) -> AggregationTemporality {

--- a/Sources/OpenTelemetrySdk/Metrics/Exporter/PeriodicMetricReaderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Metrics/Exporter/PeriodicMetricReaderSdk.swift
@@ -13,8 +13,11 @@ public final class PeriodicMetricReaderSdk: MetricReader, @unchecked Sendable {
   let exporter: MetricExporter
   let exportInterval: TimeInterval
   let scheduleQueue = DispatchQueue(label: "org.opentelemetry.StablePeriodicMetricReaderSdk.scheduleQueue")
+  let exportQueue = DispatchQueue(label: "org.opentelemetry.StablePeriodicMetricReaderSdk.exportQueue",
+                                  qos: .userInitiated)
   let scheduleTimer: DispatchSourceTimer
   let metricProduce: ReadWriteLocked<MetricProducer> = .init(initialValue: NoopMetricProducer())
+  private let hasShutdown = Locked(initialValue: false)
 
   init(exporter: MetricExporter, exportInterval: TimeInterval = 60.0) {
     self.exporter = exporter
@@ -23,17 +26,13 @@ public final class PeriodicMetricReaderSdk: MetricReader, @unchecked Sendable {
 
     scheduleTimer.setEventHandler { [weak self] in
       autoreleasepool {
-        guard let self else {
-          return
-        }
-        _ = self.doRun()
+        self?.enqueueExport()
       }
     }
   }
 
   deinit {
     _ = shutdown()
-    scheduleTimer.activate()
   }
 
   public func register(registration: CollectionRegistration) {
@@ -51,10 +50,23 @@ public final class PeriodicMetricReaderSdk: MetricReader, @unchecked Sendable {
   }
 
   public func forceFlush() -> ExportResult {
-    doRun()
+    exportQueue.sync {
+      collectAndExport()
+    }
   }
 
-  private func doRun() -> ExportResult {
+  private func enqueueExport() {
+    exportQueue.async { [weak self] in
+      autoreleasepool {
+        guard let self else {
+          return
+        }
+        _ = self.collectAndExport()
+      }
+    }
+  }
+
+  private func collectAndExport() -> ExportResult {
     let metricData = metricProduce.protectedValue.collectAllMetrics()
     if metricData.isEmpty {
       return .success
@@ -63,11 +75,23 @@ public final class PeriodicMetricReaderSdk: MetricReader, @unchecked Sendable {
   }
 
   public func shutdown() -> ExportResult {
+    let shouldShutdown = hasShutdown.locking { shutdown in
+      guard !shutdown else {
+        return false
+      }
+      shutdown = true
+      return true
+    }
+    guard shouldShutdown else {
+      return .success
+    }
+
     scheduleTimer.suspend()
     if !scheduleTimer.isCancelled {
       scheduleTimer.cancel()
       scheduleTimer.resume()
     }
+    exportQueue.sync {}
     return exporter.shutdown()
   }
 

--- a/Tests/OpenTelemetrySdkTests/Metrics/Mocks/BlockingMetricExporter.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/Mocks/BlockingMetricExporter.swift
@@ -43,6 +43,13 @@ final class BlockingMetricExporter: MetricExporter, @unchecked Sendable {
     cond.unlock()
   }
 
+  func unblock() {
+    cond.lock()
+    state = .unblocked
+    cond.unlock()
+    cond.broadcast()
+  }
+
   func flush() -> OpenTelemetrySdk.ExportResult {
     .success
   }

--- a/Tests/OpenTelemetrySdkTests/Metrics/PeriodicMetricReaderSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/PeriodicMetricReaderSdkTests.swift
@@ -61,7 +61,7 @@ final class PeriodicMetricReaderSdkTests: XCTestCase {
     XCTAssertEqual(blockingExporter.exportCallCount, 1)
 
     // Keep recording so queued collections have delta data after unblock.
-    let endTime = Date().addingTimeInterval(exportInterval * 5)
+    let endTime = Date().addingTimeInterval(exportInterval * 8)
     while Date() < endTime {
       counter.add(value: 1)
       Thread.sleep(forTimeInterval: 0.01)
@@ -71,8 +71,14 @@ final class PeriodicMetricReaderSdkTests: XCTestCase {
     XCTAssertEqual(blockingExporter.exportCallCount, 1)
 
     blockingExporter.unblock()
-    Thread.sleep(forTimeInterval: 0.2)
-    XCTAssertGreaterThanOrEqual(blockingExporter.exportCallCount, 3)
+    let start = Date()
+    let deadline = Date().addingTimeInterval(1.0)
+    while blockingExporter.exportCallCount <= 2, Date() < deadline {
+      counter.add(value: 1)
+      Thread.sleep(forTimeInterval: 0.01)
+    }
+    XCTAssertGreaterThan(blockingExporter.exportCallCount, 2)
+    XCTAssertLessThan(Date().timeIntervalSince(start), 0.3)
 
     _ = meterProvider.shutdown()
   }
@@ -155,6 +161,17 @@ final class PeriodicMetricReaderSdkTests: XCTestCase {
     XCTAssertTrue(blockingExporter.shutdownCalled)
 
     _ = meterProvider.shutdown()
+  }
+
+  func testEmptyCollectionSkipsExport() {
+    let exporter = ResultMetricExporter(result: .success)
+    let reader = PeriodicMetricReaderSdk(exporter: exporter, exportInterval: exportInterval)
+    reader.register(registration: NoopMetricProducer())
+
+    XCTAssertEqual(reader.forceFlush(), .success)
+    XCTAssertEqual(exporter.exportCallCount, 0)
+
+    _ = reader.shutdown()
   }
 
   private func makeMeterProvider(exporter: MetricExporter) -> MeterProviderSdk {

--- a/Tests/OpenTelemetrySdkTests/Metrics/PeriodicMetricReaderSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/PeriodicMetricReaderSdkTests.swift
@@ -174,6 +174,61 @@ final class PeriodicMetricReaderSdkTests: XCTestCase {
     _ = reader.shutdown()
   }
 
+  func testForceFlushReturnsFailureWhenExportTimesOut() {
+    let blockingExporter = CountingBlockingMetricExporter(aggregationTemporality: .delta)
+    let reader = PeriodicMetricReaderSdk(
+      exporter: blockingExporter,
+      exportInterval: exportInterval,
+      exportTimeout: 0.1
+    )
+    let meterProvider = makeMeterProvider(reader: reader)
+    let counter = meterProvider.meterBuilder(name: "meter").build().counterBuilder(name: "counter").build()
+
+    counter.add(value: 1)
+    blockingExporter.waitUntilIsBlocked()
+
+    let flushCompleted = expectation(description: "forceFlush completed")
+    let flushResult = Locked(initialValue: ExportResult.success)
+    flushQueue.async {
+      flushResult.locking { $0 = reader.forceFlush() }
+      flushCompleted.fulfill()
+    }
+
+    wait(for: [flushCompleted], timeout: 1.0)
+    XCTAssertEqual(flushResult.locking { $0 }, .failure)
+
+    blockingExporter.unblock()
+    _ = meterProvider.shutdown()
+  }
+
+  func testShutdownReturnsFailureWhenExportTimesOut() {
+    let blockingExporter = CountingBlockingMetricExporter(aggregationTemporality: .delta)
+    let reader = PeriodicMetricReaderSdk(
+      exporter: blockingExporter,
+      exportInterval: exportInterval,
+      exportTimeout: 0.1
+    )
+    let meterProvider = makeMeterProvider(reader: reader)
+    let counter = meterProvider.meterBuilder(name: "meter").build().counterBuilder(name: "counter").build()
+
+    counter.add(value: 1)
+    blockingExporter.waitUntilIsBlocked()
+
+    let shutdownCompleted = expectation(description: "shutdown completed")
+    let shutdownResult = Locked(initialValue: ExportResult.success)
+    flushQueue.async {
+      shutdownResult.locking { $0 = reader.shutdown() }
+      shutdownCompleted.fulfill()
+    }
+
+    wait(for: [shutdownCompleted], timeout: 1.0)
+    XCTAssertEqual(shutdownResult.locking { $0 }, .failure)
+    XCTAssertTrue(blockingExporter.shutdownCalled)
+
+    blockingExporter.unblock()
+    _ = meterProvider.shutdown()
+  }
+
   private func makeMeterProvider(exporter: MetricExporter) -> MeterProviderSdk {
     let reader = PeriodicMetricReaderSdk(exporter: exporter, exportInterval: exportInterval)
     return makeMeterProvider(reader: reader)

--- a/Tests/OpenTelemetrySdkTests/Metrics/PeriodicMetricReaderSdkTests.swift
+++ b/Tests/OpenTelemetrySdkTests/Metrics/PeriodicMetricReaderSdkTests.swift
@@ -1,0 +1,248 @@
+//
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import OpenTelemetryApi
+@testable import OpenTelemetrySdk
+import XCTest
+
+final class PeriodicMetricReaderSdkTests: XCTestCase {
+  private let exportInterval: TimeInterval = 0.05
+  private let flushQueue = DispatchQueue(label: "PeriodicMetricReaderSdkTests.flush", qos: .userInitiated)
+  private let verifyQueue = DispatchQueue(label: "PeriodicMetricReaderSdkTests.verify", qos: .userInitiated)
+
+  func testScheduledExportQueuesWhileExportIsBlocked() {
+    let blockingExporter = CountingBlockingMetricExporter(aggregationTemporality: .delta)
+    let meterProvider = makeMeterProvider(exporter: blockingExporter)
+    let counter: LongCounterSdk = meterProvider
+      .meterBuilder(name: "meter")
+      .build()
+      .counterBuilder(name: "counter")
+      .build()
+
+    counter.add(value: 1)
+    blockingExporter.waitUntilIsBlocked()
+    XCTAssertEqual(blockingExporter.exportCallCount, 1)
+
+    let endTime = Date().addingTimeInterval(exportInterval * 3)
+    while Date() < endTime {
+      counter.add(value: 1)
+      Thread.sleep(forTimeInterval: 0.01)
+    }
+
+    XCTAssertEqual(blockingExporter.exportCallCount, 1)
+
+    blockingExporter.unblock()
+    let secondExportCompleted = expectation(description: "second export completed")
+    verifyQueue.async {
+      while blockingExporter.exportCallCount < 2 {
+        Thread.sleep(forTimeInterval: 0.01)
+      }
+      secondExportCompleted.fulfill()
+    }
+    wait(for: [secondExportCompleted], timeout: 1.0)
+
+    _ = meterProvider.shutdown()
+  }
+
+  func testTimerKeepsEnqueueingWhileExportIsBlocked() {
+    let blockingExporter = CountingBlockingMetricExporter(aggregationTemporality: .delta)
+    let meterProvider = makeMeterProvider(exporter: blockingExporter)
+    let counter: LongCounterSdk = meterProvider
+      .meterBuilder(name: "meter")
+      .build()
+      .counterBuilder(name: "counter")
+      .build()
+
+    counter.add(value: 1)
+    blockingExporter.waitUntilIsBlocked()
+    XCTAssertEqual(blockingExporter.exportCallCount, 1)
+
+    // Keep recording so queued collections have delta data after unblock.
+    let endTime = Date().addingTimeInterval(exportInterval * 5)
+    while Date() < endTime {
+      counter.add(value: 1)
+      Thread.sleep(forTimeInterval: 0.01)
+    }
+
+    // Timer should keep enqueueing exports without blocking on the slow upload.
+    XCTAssertEqual(blockingExporter.exportCallCount, 1)
+
+    blockingExporter.unblock()
+    Thread.sleep(forTimeInterval: 0.2)
+    XCTAssertGreaterThanOrEqual(blockingExporter.exportCallCount, 3)
+
+    _ = meterProvider.shutdown()
+  }
+
+  func testForceFlushWaitsForInFlightExport() {
+    let blockingExporter = CountingBlockingMetricExporter(aggregationTemporality: .delta)
+    let reader = PeriodicMetricReaderSdk(exporter: blockingExporter, exportInterval: exportInterval)
+    let meterProvider = makeMeterProvider(reader: reader)
+    let counter = meterProvider.meterBuilder(name: "meter").build().counterBuilder(name: "counter").build()
+
+    counter.add(value: 1)
+    blockingExporter.waitUntilIsBlocked()
+
+    let flushCompleted = expectation(description: "forceFlush completed")
+    let flushFinished = Locked(initialValue: false)
+    let flushSucceeded = Locked(initialValue: false)
+    flushQueue.async {
+      flushSucceeded.locking { $0 = reader.forceFlush() == .success }
+      flushFinished.locking { $0 = true }
+      flushCompleted.fulfill()
+    }
+
+    let stillBlocked = expectation(description: "flush still blocked")
+    verifyQueue.async {
+      Thread.sleep(forTimeInterval: 0.1)
+      stillBlocked.fulfill()
+    }
+    wait(for: [stillBlocked], timeout: 0.2)
+    XCTAssertFalse(flushFinished.locking { $0 })
+
+    blockingExporter.unblock()
+    wait(for: [flushCompleted], timeout: 1.0)
+    XCTAssertTrue(flushSucceeded.locking { $0 })
+
+    _ = meterProvider.shutdown()
+  }
+
+  func testForceFlushReturnsExportResult() {
+    let exporter = ResultMetricExporter(result: .failure)
+    let reader = PeriodicMetricReaderSdk(exporter: exporter, exportInterval: exportInterval)
+    let meterProvider = makeMeterProvider(reader: reader)
+    let counter = meterProvider.meterBuilder(name: "meter").build().counterBuilder(name: "counter").build()
+
+    counter.add(value: 1)
+    XCTAssertEqual(reader.forceFlush(), .failure)
+
+    _ = meterProvider.shutdown()
+  }
+
+  func testShutdownDrainsPendingExports() {
+    let blockingExporter = CountingBlockingMetricExporter(aggregationTemporality: .delta)
+    let reader = PeriodicMetricReaderSdk(exporter: blockingExporter, exportInterval: exportInterval)
+    let meterProvider = makeMeterProvider(reader: reader)
+    let counter = meterProvider.meterBuilder(name: "meter").build().counterBuilder(name: "counter").build()
+
+    counter.add(value: 1)
+    blockingExporter.waitUntilIsBlocked()
+
+    let shutdownCompleted = expectation(description: "shutdown completed")
+    let shutdownFinished = Locked(initialValue: false)
+    let shutdownSucceeded = Locked(initialValue: false)
+    flushQueue.async {
+      shutdownSucceeded.locking { $0 = reader.shutdown() == .success }
+      shutdownFinished.locking { $0 = true }
+      shutdownCompleted.fulfill()
+    }
+
+    let stillBlocked = expectation(description: "shutdown still blocked")
+    verifyQueue.async {
+      Thread.sleep(forTimeInterval: 0.1)
+      stillBlocked.fulfill()
+    }
+    wait(for: [stillBlocked], timeout: 0.2)
+    XCTAssertFalse(shutdownFinished.locking { $0 })
+
+    blockingExporter.unblock()
+    wait(for: [shutdownCompleted], timeout: 1.0)
+    XCTAssertTrue(shutdownSucceeded.locking { $0 })
+    XCTAssertEqual(blockingExporter.exportCallCount, 1)
+    XCTAssertTrue(blockingExporter.shutdownCalled)
+
+    _ = meterProvider.shutdown()
+  }
+
+  private func makeMeterProvider(exporter: MetricExporter) -> MeterProviderSdk {
+    let reader = PeriodicMetricReaderSdk(exporter: exporter, exportInterval: exportInterval)
+    return makeMeterProvider(reader: reader)
+  }
+
+  private func makeMeterProvider(reader: PeriodicMetricReaderSdk) -> MeterProviderSdk {
+    MeterProviderSdk.builder()
+      .registerMetricReader(reader: reader)
+      .registerView(
+        selector: InstrumentSelectorBuilder().build(),
+        view: View.builder().build()
+      )
+      .build()
+  }
+}
+
+private final class CountingBlockingMetricExporter: MetricExporter, @unchecked Sendable {
+  private let blockingExporter: BlockingMetricExporter
+  private let exportCallCountState = Locked(initialValue: 0)
+  private let shutdownCalledState = Locked(initialValue: false)
+
+  var exportCallCount: Int {
+    exportCallCountState.locking { $0 }
+  }
+
+  var shutdownCalled: Bool {
+    shutdownCalledState.locking { $0 }
+  }
+
+  init(aggregationTemporality: AggregationTemporality) {
+    blockingExporter = BlockingMetricExporter(aggregationTemporality: aggregationTemporality)
+  }
+
+  func export(metrics: [MetricData]) -> ExportResult {
+    exportCallCountState.locking { $0 += 1 }
+    return blockingExporter.export(metrics: metrics)
+  }
+
+  func waitUntilIsBlocked() {
+    blockingExporter.waitUntilIsBlocked()
+  }
+
+  func unblock() {
+    blockingExporter.unblock()
+  }
+
+  func flush() -> ExportResult {
+    blockingExporter.flush()
+  }
+
+  func shutdown() -> ExportResult {
+    shutdownCalledState.locking { $0 = true }
+    return blockingExporter.shutdown()
+  }
+
+  func getAggregationTemporality(for instrument: InstrumentType) -> AggregationTemporality {
+    blockingExporter.getAggregationTemporality(for: instrument)
+  }
+}
+
+private final class ResultMetricExporter: MetricExporter, @unchecked Sendable {
+  private let result: ExportResult
+  private let exportCallCountState = Locked(initialValue: 0)
+
+  var exportCallCount: Int {
+    exportCallCountState.locking { $0 }
+  }
+
+  init(result: ExportResult) {
+    self.result = result
+  }
+
+  func export(metrics: [MetricData]) -> ExportResult {
+    exportCallCountState.locking { $0 += 1 }
+    return result
+  }
+
+  func flush() -> ExportResult {
+    .success
+  }
+
+  func shutdown() -> ExportResult {
+    .success
+  }
+
+  func getAggregationTemporality(for instrument: InstrumentType) -> AggregationTemporality {
+    .delta
+  }
+}


### PR DESCRIPTION
## Summary
- Move collect+export off the schedule timer queue onto a serial `exportQueue`, so slow/blocking exporters (e.g. OTLP HTTP with synchronous wait) do not stall periodic collection.
- Add `exportTimeout` (default 30s) to bound `forceFlush` and `shutdown`.
- Add regression tests for non-blocking timer behavior, queue draining, and export result propagation.

## Motivation
`OtlpHttpMetricExporter.export()` must wait for the HTTP callback to return the real `ExportResult` (see open-telemetry/opentelemetry-swift#1146). On core 2.5.1, `PeriodicMetricReaderSdk` calls `exporter.export()` synchronously on `scheduleQueue`, so a `DispatchSemaphore` in the exporter blocks the timer and stops metric collection.

## Test plan
- [x] `swift test --filter PeriodicMetricReaderSdkTests` (core repo)
- [x] Integration https://github.com/open-telemetry/opentelemetry-swift/pull/1189 
- [x] Full core test suite