### PR TITLE
Enforce the W3C Baggage limits when extracting the baggage header

### DIFF
--- a/Sources/OpenTelemetryApi/Baggage/Propagation/W3CBaggagePropagator.swift
+++ b/Sources/OpenTelemetryApi/Baggage/Propagation/W3CBaggagePropagator.swift
@@ -20,11 +20,34 @@ public struct W3CBaggagePropagator: TextMapBaggagePropagator {
 
   static let headerBaggage = "baggage"
 
+  /// The maximum number of list-members accepted from the header. The value is 64.
+  /// https://www.w3.org/TR/baggage/#limits
+  static let maxListMembers = 64
+  /// The maximum number of bytes read from the header. The value is 8192.
+  static let maxHeaderBytes = 8192
+
   private func isValidKeyValuePair(_ keyValue: String) -> (key: String, value: String)? {
     let parts = keyValue.split(separator: "=", maxSplits: 1)
     guard parts.count == 2 else { return nil }
 
     return (String(parts[0]), String(parts[1]))
+  }
+
+  /// Splits the header into list-members, ignoring everything past maxHeaderBytes.
+  /// The cut is made at the last separator before the limit, so no list-member is kept in part.
+  private static func listMembers(in header: String) -> [String] {
+    let bytes = header.utf8
+    guard bytes.count > maxHeaderBytes else {
+      return header.components(separatedBy: ",")
+    }
+
+    let window = bytes.prefix(maxHeaderBytes + 1)
+    guard let lastSeparator = window.lastIndex(of: UInt8(ascii: ",")),
+          let head = String(bytes: window[..<lastSeparator], encoding: .utf8) else {
+      return []
+    }
+
+    return head.components(separatedBy: ",")
   }
 
   public init() {}
@@ -65,8 +88,12 @@ public struct W3CBaggagePropagator: TextMapBaggagePropagator {
 
     let builder = OpenTelemetry.instance.baggageManager.baggageBuilder()
 
-    let listMembers = baggageHeader.components(separatedBy: ",")
-    for listMember in listMembers {
+    var accepted = 0
+    for listMember in W3CBaggagePropagator.listMembers(in: baggageHeader) {
+      if accepted == W3CBaggagePropagator.maxListMembers {
+        break
+      }
+
       let parts = listMember.split(separator: ";", maxSplits: 1)
       guard !parts.isEmpty else { continue }
 
@@ -82,6 +109,7 @@ public struct W3CBaggagePropagator: TextMapBaggagePropagator {
       builder.put(key: entryKey,
                   value: entryValue,
                   metadata: EntryMetadata(metadata: metadata))
+      accepted += 1
     }
 
     return builder.build()

--- a/Tests/OpenTelemetryApiTests/Baggage/Propagation/W3CBaggagePropagatorTest.swift
+++ b/Tests/OpenTelemetryApiTests/Baggage/Propagation/W3CBaggagePropagatorTest.swift
@@ -219,4 +219,82 @@ class W3BaggagePropagatorTest: XCTestCase {
                      "Should accept valid input: \(validInput)")
     }
   }
+
+  // MARK: - Limits (https://www.w3.org/TR/baggage/#limits)
+
+  // A 400-byte list-member. Keys and values are capped at 255, so the length goes into the properties.
+  private func longListMember(_ index: Int) -> String {
+    return String(format: "k%02d=v;", index) + String(repeating: "m", count: 394)
+  }
+
+  func testW3CMaxListMembers() {
+    let header = (0 ..< 65).map { "k\($0)=v" }.joined(separator: ",")
+
+    let result = propagator.extract(carrier: ["baggage": header], getter: getter)!
+
+    XCTAssertEqual(result.getEntries().count, 64)
+    XCTAssertNotNil(result.getEntryValue(key: EntryKey(name: "k63")!))
+    XCTAssertNil(result.getEntryValue(key: EntryKey(name: "k64")!))
+  }
+
+  func testW3CExactlyMaxListMembers() {
+    let header = (0 ..< 64).map { "k\($0)=v" }.joined(separator: ",")
+
+    let result = propagator.extract(carrier: ["baggage": header], getter: getter)!
+
+    XCTAssertEqual(result.getEntries().count, 64)
+  }
+
+  func testW3CInvalidListMembersDoNotCount() {
+    // 64 invalid members followed by a valid one: the valid one is still accepted.
+    let header = Array(repeating: "=", count: 64).joined(separator: ",") + ",k=v"
+
+    let result = propagator.extract(carrier: ["baggage": header], getter: getter)!
+
+    XCTAssertEqual(result.getEntries().count, 1)
+    XCTAssertNotNil(result.getEntryValue(key: EntryKey(name: "k")!))
+  }
+
+  func testW3CHeaderOverMaxBytes() {
+    // 30 members of 400 bytes. The last separator inside the first 8193 bytes follows the 20th member.
+    let header = (0 ..< 30).map(longListMember).joined(separator: ",")
+    XCTAssertEqual(header.utf8.count, 30 * 400 + 29)
+
+    let result = propagator.extract(carrier: ["baggage": header], getter: getter)!
+
+    XCTAssertEqual(result.getEntries().count, 20)
+    XCTAssertNotNil(result.getEntryValue(key: EntryKey(name: "k19")!))
+    XCTAssertNil(result.getEntryValue(key: EntryKey(name: "k20")!))
+  }
+
+  func testW3CHeaderAtMaxBytes() {
+    var members = (0 ..< 20).map(longListMember) // 20 * 400 + 19 separators = 8019 bytes
+    members.append("k20=v;" + String(repeating: "m", count: 166)) // + 1 separator + 172 = 8192
+    let header = members.joined(separator: ",")
+    XCTAssertEqual(header.utf8.count, 8192)
+
+    let result = propagator.extract(carrier: ["baggage": header], getter: getter)!
+
+    XCTAssertEqual(result.getEntries().count, 21)
+  }
+
+  func testW3CPartialListMemberDropped() {
+    // The second member straddles the 8192-byte limit and is dropped whole.
+    let members = ["k0=v;" + String(repeating: "m", count: 8000),
+                   "k1=v;" + String(repeating: "m", count: 500)]
+
+    let result = propagator.extract(carrier: ["baggage": members.joined(separator: ",")], getter: getter)!
+
+    XCTAssertEqual(result.getEntries().count, 1)
+    XCTAssertNotNil(result.getEntryValue(key: EntryKey(name: "k0")!))
+    XCTAssertNil(result.getEntryValue(key: EntryKey(name: "k1")!))
+  }
+
+  func testW3CNoListMemberFits() {
+    let header = "k=v;" + String(repeating: "m", count: 9000)
+
+    let result = propagator.extract(carrier: ["baggage": header], getter: getter)
+
+    XCTAssertEqual(result?.getEntries().count ?? 0, 0)
+  }
 }


### PR DESCRIPTION
Part of #108.

`W3CBaggagePropagator.extract` kept every list-member of the `baggage` header. The W3C Baggage spec (https://www.w3.org/TR/baggage/#limits) sets the limits a platform must handle at 64 list-members and 8192 bytes, and says that when list-members are dropped none may be kept in part.

This applies those two limits on extract, the way `TraceStateUtils` already applies the 32-member cap on `tracestate`: a header over 8192 bytes is cut back to the last `,` so that what is kept fits in 8192 bytes, and at most 64 list-members are accepted; malformed members do not count. Inject and the empty-header behavior are unchanged. This is a behavior change for headers past either limit, which were kept in full before.

The constants are the Candidate Recommendation's (64 / 8192, as in opentelemetry-java, -go and -rust); the 2020 draft's 180 / 4096 / 8192 are still used by the Python, JS and Ruby SDKs.

Seven tests: 65 list-members keep 64; exactly 64 are kept; 64 malformed members do not shadow a valid one; a 12,029-byte header is cut after its 20th member; a header of exactly 8192 bytes is kept whole; a member straddling the limit is dropped whole; a header where no member fits yields no entries. `swift test`: 574 tests, 0 failures on macOS (Xcode 26.6) and on Linux (swift 6.1).

AI-assisted; reviewed and tested by me.
