### PR TITLE
Bound Jaeger and Zipkin baggage extraction with the W3C Baggage limits

### DIFF
--- a/Sources/OpenTelemetryApi/Baggage/Propagation/BaggageExtractLimits.swift
+++ b/Sources/OpenTelemetryApi/Baggage/Propagation/BaggageExtractLimits.swift
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Foundation
+
+/// Bounds the entries a propagator accepts from a carrier. The limits are the W3C Baggage ones,
+/// used for formats that define none of their own. https://www.w3.org/TR/baggage/#limits
+struct BaggageExtractLimits {
+  /// The maximum number of entries. The value is 64.
+  static let maxEntries = 64
+  /// The maximum number of bytes of keys and values together. The value is 8192.
+  static let maxBytes = 8192
+
+  private(set) var entries = 0
+  private(set) var bytes = 0
+
+  /// Returns whether the entry fits, and counts it if it does.
+  mutating func accept(key: EntryKey, value: EntryValue) -> Bool {
+    let size = key.name.utf8.count + value.string.utf8.count
+    guard entries < BaggageExtractLimits.maxEntries, bytes + size <= BaggageExtractLimits.maxBytes else {
+      return false
+    }
+
+    entries += 1
+    bytes += size
+    return true
+  }
+}

--- a/Sources/OpenTelemetryApi/Baggage/Propagation/JaegerBaggagePropagator.swift
+++ b/Sources/OpenTelemetryApi/Baggage/Propagation/JaegerBaggagePropagator.swift
@@ -8,6 +8,8 @@ import Foundation
 /**
  * Implementation of the Jaeger propagation protocol. See
  * https://www.jaegertracing.io/docs/client-libraries/#propagation-format
+ *
+ * The Jaeger format defines no limits on baggage; the W3C Baggage limits are applied on extraction.
  */
 
 public class JaegerBaggagePropagator: TextMapBaggagePropagator {
@@ -26,6 +28,7 @@ public class JaegerBaggagePropagator: TextMapBaggagePropagator {
 
   public func extract(carrier: [String: String], getter: some Getter) -> Baggage? {
     let builder = OpenTelemetry.instance.baggageManager.baggageBuilder()
+    var limits = BaggageExtractLimits()
 
     carrier.forEach {
       if $0.key.hasPrefix(JaegerBaggagePropagator.baggagePrefix) {
@@ -34,7 +37,8 @@ public class JaegerBaggagePropagator: TextMapBaggagePropagator {
         }
 
         if let key = EntryKey(name: String($0.key.dropFirst(JaegerBaggagePropagator.baggagePrefix.count))),
-           let value = EntryValue(string: $0.value) {
+           let value = EntryValue(string: $0.value),
+           limits.accept(key: key, value: value) {
           builder.put(key: key, value: value, metadata: nil)
         }
       } else if $0.key == JaegerBaggagePropagator.baggageHeader {
@@ -44,7 +48,8 @@ public class JaegerBaggagePropagator: TextMapBaggagePropagator {
             return
           }
           if let key = EntryKey(name: String(keyValue[0])),
-             let value = EntryValue(string: String(keyValue[1])) {
+             let value = EntryValue(string: String(keyValue[1])),
+             limits.accept(key: key, value: value) {
             builder.put(key: key, value: value, metadata: nil)
           }
         }

--- a/Sources/OpenTelemetryApi/Baggage/Propagation/ZipkinBaggagePropagator.swift
+++ b/Sources/OpenTelemetryApi/Baggage/Propagation/ZipkinBaggagePropagator.swift
@@ -8,6 +8,8 @@ import Foundation
 /**
  * Implementation of the Zipkin propagation protocol and by default it uses `baggage-` prefix. See
  * https://github.com/openzipkin/brave/blob/master/brave/README.md#remote-baggage
+ *
+ * The Zipkin format defines no limits on baggage; the W3C Baggage limits are applied on extraction.
  */
 
 public class ZipkinBaggagePropagator: TextMapBaggagePropagator {
@@ -25,6 +27,7 @@ public class ZipkinBaggagePropagator: TextMapBaggagePropagator {
 
   public func extract(carrier: [String: String], getter: some Getter) -> Baggage? {
     let builder = OpenTelemetry.instance.baggageManager.baggageBuilder()
+    var limits = BaggageExtractLimits()
 
     carrier.forEach {
       if $0.key.hasPrefix(ZipkinBaggagePropagator.baggagePrefix) {
@@ -33,7 +36,8 @@ public class ZipkinBaggagePropagator: TextMapBaggagePropagator {
         }
 
         if let key = EntryKey(name: String($0.key.dropFirst(ZipkinBaggagePropagator.baggagePrefix.count))),
-           let value = EntryValue(string: $0.value) {
+           let value = EntryValue(string: $0.value),
+           limits.accept(key: key, value: value) {
           builder.put(key: key, value: value, metadata: nil)
         }
       }

--- a/Tests/OpenTelemetryApiTests/Baggage/Propagation/BaggageExtractLimitsTests.swift
+++ b/Tests/OpenTelemetryApiTests/Baggage/Propagation/BaggageExtractLimitsTests.swift
@@ -1,0 +1,53 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+@testable import OpenTelemetryApi
+import XCTest
+
+class BaggageExtractLimitsTests: XCTestCase {
+  func testMaxEntries() throws {
+    var limits = BaggageExtractLimits()
+    for index in 0 ..< BaggageExtractLimits.maxEntries {
+      XCTAssertTrue(try limits.accept(key: XCTUnwrap(EntryKey(name: "k\(index)")), value: XCTUnwrap(EntryValue(string: "v"))))
+    }
+
+    XCTAssertFalse(try limits.accept(key: XCTUnwrap(EntryKey(name: "one-too-many")), value: XCTUnwrap(EntryValue(string: "v"))))
+    XCTAssertEqual(limits.entries, BaggageExtractLimits.maxEntries)
+  }
+
+  func testMaxBytes() throws {
+    var limits = BaggageExtractLimits()
+    let key = try XCTUnwrap(EntryKey(name: String(repeating: "k", count: 200))) // 200 + 200 = 400 bytes per entry
+    let value = try XCTUnwrap(EntryValue(string: String(repeating: "v", count: 200)))
+    for _ in 0 ..< 20 { // 8000 bytes
+      XCTAssertTrue(limits.accept(key: key, value: value))
+    }
+
+    XCTAssertFalse(limits.accept(key: key, value: value)) // 8400 > 8192
+    XCTAssertTrue(try limits.accept(key: XCTUnwrap(EntryKey(name: "k")), value: XCTUnwrap(EntryValue(string: String(repeating: "v", count: 191))))) // exactly 8192
+    XCTAssertEqual(limits.bytes, BaggageExtractLimits.maxBytes)
+  }
+
+  func testRefusedEntryNotCounted() throws {
+    var limits = BaggageExtractLimits()
+    let key = try XCTUnwrap(EntryKey(name: String(repeating: "k", count: 200)))
+    let value = try XCTUnwrap(EntryValue(string: String(repeating: "v", count: 200)))
+    for _ in 0 ..< 20 {
+      _ = limits.accept(key: key, value: value)
+    }
+
+    XCTAssertFalse(limits.accept(key: key, value: value))
+
+    XCTAssertEqual(limits.entries, 20)
+    XCTAssertEqual(limits.bytes, 8000)
+  }
+
+  func testCountsUTF8Bytes() throws {
+    var limits = BaggageExtractLimits()
+    XCTAssertTrue(try limits.accept(key: XCTUnwrap(EntryKey(name: "k")), value: XCTUnwrap(EntryValue(string: "é")))) // 1 + 2 bytes
+
+    XCTAssertEqual(limits.bytes, 3)
+  }
+}

--- a/Tests/OpenTelemetryApiTests/Baggage/Propagation/JaegerBaggagePropagatorTests.swift
+++ b/Tests/OpenTelemetryApiTests/Baggage/Propagation/JaegerBaggagePropagatorTests.swift
@@ -96,4 +96,56 @@ class JaegerBaggagePropagatorTests: XCTestCase {
     let result = jaegerPropagator.extract(carrier: carrier, getter: getter)
     XCTAssertEqual(result?.getEntries().sorted(), expectedBaggage.getEntries().sorted())
   }
+
+  // MARK: - Limits borrowed from W3C Baggage (https://www.w3.org/TR/baggage/#limits)
+
+  func testExtractMaxEntriesWithPrefix() {
+    var carrier = [String: String]()
+    for index in 0 ..< 65 {
+      carrier[JaegerBaggagePropagator.baggagePrefix + "k\(index)"] = "v"
+    }
+
+    let result = jaegerPropagator.extract(carrier: carrier, getter: getter)!
+    XCTAssertEqual(result.getEntries().count, 64)
+  }
+
+  func testExtractExactlyMaxEntriesWithPrefix() {
+    var carrier = [String: String]()
+    for index in 0 ..< 64 {
+      carrier[JaegerBaggagePropagator.baggagePrefix + "k\(index)"] = "v"
+    }
+
+    let result = jaegerPropagator.extract(carrier: carrier, getter: getter)!
+    XCTAssertEqual(result.getEntries().count, 64)
+  }
+
+  func testExtractMaxEntriesWithHeader() {
+    var carrier = [String: String]()
+    carrier[JaegerBaggagePropagator.baggageHeader] = (0 ..< 65).map { "k\($0)=v" }.joined(separator: ",")
+
+    let result = jaegerPropagator.extract(carrier: carrier, getter: getter)!
+    XCTAssertEqual(result.getEntries().count, 64)
+  }
+
+  func testExtractPrefixAndHeaderShareLimit() {
+    var carrier = [String: String]()
+    for index in 0 ..< 40 {
+      carrier[JaegerBaggagePropagator.baggagePrefix + "p\(index)"] = "v"
+    }
+    carrier[JaegerBaggagePropagator.baggageHeader] = (0 ..< 40).map { "h\($0)=v" }.joined(separator: ",")
+
+    let result = jaegerPropagator.extract(carrier: carrier, getter: getter)!
+    XCTAssertEqual(result.getEntries().count, 64)
+  }
+
+  func testExtractMaxBytes() {
+    // 32 entries of 260 bytes are 8320 bytes. 31 fit (8060), the 32nd does not.
+    var carrier = [String: String]()
+    for index in 0 ..< 32 {
+      carrier[JaegerBaggagePropagator.baggagePrefix + String(format: "key%07d", index)] = String(repeating: "v", count: 250)
+    }
+
+    let result = jaegerPropagator.extract(carrier: carrier, getter: getter)!
+    XCTAssertEqual(result.getEntries().count, 31)
+  }
 }

--- a/Tests/OpenTelemetryApiTests/Baggage/Propagation/ZipkinBaggagePropagatorTests.swift
+++ b/Tests/OpenTelemetryApiTests/Baggage/Propagation/ZipkinBaggagePropagatorTests.swift
@@ -50,4 +50,37 @@ class ZipkinBaggagePropagatorTests: XCTestCase {
     let result = zipkinPropagator.extract(carrier: carrier, getter: getter)!
     XCTAssertTrue(result.getEntries().isEmpty)
   }
+
+  // MARK: - Limits borrowed from W3C Baggage (https://www.w3.org/TR/baggage/#limits)
+
+  func testExtractMaxEntries() {
+    var carrier = [String: String]()
+    for index in 0 ..< 65 {
+      carrier[ZipkinBaggagePropagator.baggagePrefix + "k\(index)"] = "v"
+    }
+
+    let result = zipkinPropagator.extract(carrier: carrier, getter: getter)!
+    XCTAssertEqual(result.getEntries().count, 64)
+  }
+
+  func testExtractExactlyMaxEntries() {
+    var carrier = [String: String]()
+    for index in 0 ..< 64 {
+      carrier[ZipkinBaggagePropagator.baggagePrefix + "k\(index)"] = "v"
+    }
+
+    let result = zipkinPropagator.extract(carrier: carrier, getter: getter)!
+    XCTAssertEqual(result.getEntries().count, 64)
+  }
+
+  func testExtractMaxBytes() {
+    // 32 entries of 260 bytes are 8320 bytes. 31 fit (8060), the 32nd does not.
+    var carrier = [String: String]()
+    for index in 0 ..< 32 {
+      carrier[ZipkinBaggagePropagator.baggagePrefix + String(format: "key%07d", index)] = String(repeating: "v", count: 250)
+    }
+
+    let result = zipkinPropagator.extract(carrier: carrier, getter: getter)!
+    XCTAssertEqual(result.getEntries().count, 31)
+  }
 }


### PR DESCRIPTION
Part of #108.

`JaegerBaggagePropagator.extract` and `ZipkinBaggagePropagator.extract` kept every `uberctx-*` / `baggage-*` key and every pair of `jaeger-baggage`. Neither format defines a limit.

This borrows the W3C Baggage limits for both, as opentelemetry-java did for its Jaeger and OtTrace propagators in 1.62.0 ("No limits are defined by the Jaeger format; borrow the W3C Baggage spec limits as a defense-in-depth measure"): at most 64 entries and 8192 bytes of keys and values per extract, counted in a small internal `BaggageExtractLimits` that both propagators share and that has its own tests. Jaeger's prefixed keys and its header share one budget. An entry that does not fit is skipped and not counted.

The carrier is a dictionary, so which 64 entries survive an oversized carrier depends on its iteration order — the same holds in opentelemetry-java, and the tests assert counts.

Four tests on `BaggageExtractLimits` and eight across the two propagators: 65 entries keep 64, for prefixed keys, for the header and for Zipkin; 40 prefixed plus 40 header keep 64; 32 entries of 260 bytes keep 31; exactly 64 are accepted. `swift test`: 579 tests, 0 failures on macOS (Xcode 26.6) and on Linux (swift 6.1).

AI-assisted; reviewed and tested by me.
