### PR TITLE
Apply the W3C Baggage limits when injecting, not only when extracting

### DIFF
--- a/Sources/OpenTelemetryApi/Baggage/Propagation/BaggagePropagationLimits.swift
+++ b/Sources/OpenTelemetryApi/Baggage/Propagation/BaggagePropagationLimits.swift
@@ -5,9 +5,9 @@
 
 import Foundation
 
-/// Bounds the entries a propagator accepts from a carrier. The limits are the W3C Baggage ones,
-/// used for formats that define none of their own. https://www.w3.org/TR/baggage/#limits
-struct BaggageExtractLimits {
+/// Bounds the entries a propagator accepts from a carrier or writes to one. The limits are the
+/// W3C Baggage ones, used for formats that define none of their own. https://www.w3.org/TR/baggage/#limits
+struct BaggagePropagationLimits {
   /// The maximum number of entries. The value is 64.
   static let maxEntries = 64
   /// The maximum number of bytes of keys and values together. The value is 8192.
@@ -16,10 +16,10 @@ struct BaggageExtractLimits {
   private(set) var entries = 0
   private(set) var bytes = 0
 
-  /// Returns whether the entry fits, and counts it if it does.
+  /// Returns whether the entry fits the remaining budget, and counts it if it does.
   mutating func accept(key: EntryKey, value: EntryValue) -> Bool {
     let size = key.name.utf8.count + value.string.utf8.count
-    guard entries < BaggageExtractLimits.maxEntries, bytes + size <= BaggageExtractLimits.maxBytes else {
+    guard entries < BaggagePropagationLimits.maxEntries, bytes + size <= BaggagePropagationLimits.maxBytes else {
       return false
     }
 

--- a/Sources/OpenTelemetryApi/Baggage/Propagation/JaegerBaggagePropagator.swift
+++ b/Sources/OpenTelemetryApi/Baggage/Propagation/JaegerBaggagePropagator.swift
@@ -9,7 +9,7 @@ import Foundation
  * Implementation of the Jaeger propagation protocol. See
  * https://www.jaegertracing.io/docs/client-libraries/#propagation-format
  *
- * The Jaeger format defines no limits on baggage; the W3C Baggage limits are applied on extraction.
+ * The Jaeger format defines no limits on baggage; the W3C Baggage limits are applied to the keys and values on extraction and injection.
  */
 
 public class JaegerBaggagePropagator: TextMapBaggagePropagator {
@@ -21,14 +21,21 @@ public class JaegerBaggagePropagator: TextMapBaggagePropagator {
   public init() {}
 
   public func inject(baggage: Baggage, carrier: inout [String: String], setter: some Setter) {
-    baggage.getEntries().forEach {
+    var limits = BaggagePropagationLimits()
+
+    // Sorted so that the entries kept at capacity are the same on every peer and every run.
+    baggage.getEntries().sorted().forEach {
+      guard limits.accept(key: $0.key, value: $0.value) else {
+        return
+      }
+
       setter.set(carrier: &carrier, key: JaegerBaggagePropagator.baggagePrefix + $0.key.name, value: $0.value.string)
     }
   }
 
   public func extract(carrier: [String: String], getter: some Getter) -> Baggage? {
     let builder = OpenTelemetry.instance.baggageManager.baggageBuilder()
-    var limits = BaggageExtractLimits()
+    var limits = BaggagePropagationLimits()
 
     carrier.forEach {
       if $0.key.hasPrefix(JaegerBaggagePropagator.baggagePrefix) {

--- a/Sources/OpenTelemetryApi/Baggage/Propagation/W3CBaggagePropagator.swift
+++ b/Sources/OpenTelemetryApi/Baggage/Propagation/W3CBaggagePropagator.swift
@@ -56,8 +56,14 @@ public struct W3CBaggagePropagator: TextMapBaggagePropagator {
 
   public func inject(baggage: Baggage, carrier: inout [String: String], setter: some Setter) {
     var headerParts: [String] = []
+    var headerBytes = 0
 
-    for entry in baggage.getEntries() {
+    // Sorted so that the members kept at capacity are the same on every peer and every run.
+    for entry in baggage.getEntries().sorted() {
+      if headerParts.count == W3CBaggagePropagator.maxListMembers {
+        break
+      }
+
       let key = entry.key.name.trimmingCharacters(in: .whitespaces)
       guard !key.isEmpty else { continue }
 
@@ -71,7 +77,12 @@ public struct W3CBaggagePropagator: TextMapBaggagePropagator {
         part += ";\(metadata)"
       }
 
+      // The separator counts towards the header the limit is set on.
+      let separator = headerParts.isEmpty ? 0 : 1
+      guard headerBytes + separator + part.utf8.count <= W3CBaggagePropagator.maxHeaderBytes else { continue }
+
       headerParts.append(part)
+      headerBytes += separator + part.utf8.count
     }
 
     let headerContent = headerParts.joined(separator: ",")

--- a/Sources/OpenTelemetryApi/Baggage/Propagation/ZipkinBaggagePropagator.swift
+++ b/Sources/OpenTelemetryApi/Baggage/Propagation/ZipkinBaggagePropagator.swift
@@ -9,7 +9,7 @@ import Foundation
  * Implementation of the Zipkin propagation protocol and by default it uses `baggage-` prefix. See
  * https://github.com/openzipkin/brave/blob/master/brave/README.md#remote-baggage
  *
- * The Zipkin format defines no limits on baggage; the W3C Baggage limits are applied on extraction.
+ * The Zipkin format defines no limits on baggage; the W3C Baggage limits are applied to the keys and values on extraction and injection.
  */
 
 public class ZipkinBaggagePropagator: TextMapBaggagePropagator {
@@ -20,14 +20,21 @@ public class ZipkinBaggagePropagator: TextMapBaggagePropagator {
   public init() {}
 
   public func inject(baggage: Baggage, carrier: inout [String: String], setter: some Setter) {
-    baggage.getEntries().forEach {
+    var limits = BaggagePropagationLimits()
+
+    // Sorted so that the entries kept at capacity are the same on every peer and every run.
+    baggage.getEntries().sorted().forEach {
+      guard limits.accept(key: $0.key, value: $0.value) else {
+        return
+      }
+
       setter.set(carrier: &carrier, key: ZipkinBaggagePropagator.baggagePrefix + $0.key.name, value: $0.value.string)
     }
   }
 
   public func extract(carrier: [String: String], getter: some Getter) -> Baggage? {
     let builder = OpenTelemetry.instance.baggageManager.baggageBuilder()
-    var limits = BaggageExtractLimits()
+    var limits = BaggagePropagationLimits()
 
     carrier.forEach {
       if $0.key.hasPrefix(ZipkinBaggagePropagator.baggagePrefix) {

--- a/Tests/OpenTelemetryApiTests/Baggage/Propagation/BaggagePropagationLimitsTests.swift
+++ b/Tests/OpenTelemetryApiTests/Baggage/Propagation/BaggagePropagationLimitsTests.swift
@@ -6,19 +6,19 @@
 @testable import OpenTelemetryApi
 import XCTest
 
-class BaggageExtractLimitsTests: XCTestCase {
+class BaggagePropagationLimitsTests: XCTestCase {
   func testMaxEntries() throws {
-    var limits = BaggageExtractLimits()
-    for index in 0 ..< BaggageExtractLimits.maxEntries {
+    var limits = BaggagePropagationLimits()
+    for index in 0 ..< BaggagePropagationLimits.maxEntries {
       XCTAssertTrue(try limits.accept(key: XCTUnwrap(EntryKey(name: "k\(index)")), value: XCTUnwrap(EntryValue(string: "v"))))
     }
 
     XCTAssertFalse(try limits.accept(key: XCTUnwrap(EntryKey(name: "one-too-many")), value: XCTUnwrap(EntryValue(string: "v"))))
-    XCTAssertEqual(limits.entries, BaggageExtractLimits.maxEntries)
+    XCTAssertEqual(limits.entries, BaggagePropagationLimits.maxEntries)
   }
 
   func testMaxBytes() throws {
-    var limits = BaggageExtractLimits()
+    var limits = BaggagePropagationLimits()
     let key = try XCTUnwrap(EntryKey(name: String(repeating: "k", count: 200))) // 200 + 200 = 400 bytes per entry
     let value = try XCTUnwrap(EntryValue(string: String(repeating: "v", count: 200)))
     for _ in 0 ..< 20 { // 8000 bytes
@@ -27,11 +27,11 @@ class BaggageExtractLimitsTests: XCTestCase {
 
     XCTAssertFalse(limits.accept(key: key, value: value)) // 8400 > 8192
     XCTAssertTrue(try limits.accept(key: XCTUnwrap(EntryKey(name: "k")), value: XCTUnwrap(EntryValue(string: String(repeating: "v", count: 191))))) // exactly 8192
-    XCTAssertEqual(limits.bytes, BaggageExtractLimits.maxBytes)
+    XCTAssertEqual(limits.bytes, BaggagePropagationLimits.maxBytes)
   }
 
   func testRefusedEntryNotCounted() throws {
-    var limits = BaggageExtractLimits()
+    var limits = BaggagePropagationLimits()
     let key = try XCTUnwrap(EntryKey(name: String(repeating: "k", count: 200)))
     let value = try XCTUnwrap(EntryValue(string: String(repeating: "v", count: 200)))
     for _ in 0 ..< 20 {
@@ -45,7 +45,7 @@ class BaggageExtractLimitsTests: XCTestCase {
   }
 
   func testCountsUTF8Bytes() throws {
-    var limits = BaggageExtractLimits()
+    var limits = BaggagePropagationLimits()
     XCTAssertTrue(try limits.accept(key: XCTUnwrap(EntryKey(name: "k")), value: XCTUnwrap(EntryValue(string: "é")))) // 1 + 2 bytes
 
     XCTAssertEqual(limits.bytes, 3)

--- a/Tests/OpenTelemetryApiTests/Baggage/Propagation/JaegerBaggagePropagatorTests.swift
+++ b/Tests/OpenTelemetryApiTests/Baggage/Propagation/JaegerBaggagePropagatorTests.swift
@@ -148,4 +148,46 @@ class JaegerBaggagePropagatorTests: XCTestCase {
     let result = jaegerPropagator.extract(carrier: carrier, getter: getter)!
     XCTAssertEqual(result.getEntries().count, 31)
   }
+
+  func testInjectMaxEntries() {
+    var carrier = [String: String]()
+    let builder = DefaultBaggageBuilder()
+    for index in 0 ..< 65 {
+      builder.put(key: String(format: "k%02d", index), value: "v")
+    }
+
+    jaegerPropagator.inject(baggage: builder.setNoParent().build(), carrier: &carrier, setter: setter)
+
+    XCTAssertEqual(carrier.keys.filter { $0.hasPrefix(JaegerBaggagePropagator.baggagePrefix) }.count, 64)
+    // Entries are sorted before the limit applies, so the same 64 are kept on every run.
+    XCTAssertNotNil(carrier[JaegerBaggagePropagator.baggagePrefix + "k63"])
+    XCTAssertNil(carrier[JaegerBaggagePropagator.baggagePrefix + "k64"])
+  }
+
+  func testInjectMaxBytes() {
+    // 32 entries of 260 bytes are 8320 bytes. 31 fit (8060), the 32nd does not.
+    var carrier = [String: String]()
+    let builder = DefaultBaggageBuilder()
+    for index in 0 ..< 32 {
+      builder.put(key: String(format: "key%07d", index), value: String(repeating: "v", count: 250))
+    }
+
+    jaegerPropagator.inject(baggage: builder.setNoParent().build(), carrier: &carrier, setter: setter)
+
+    XCTAssertEqual(carrier.keys.filter { $0.hasPrefix(JaegerBaggagePropagator.baggagePrefix) }.count, 31)
+  }
+
+  func testInjectCountsBytesNotCharacters() {
+    // Values are written through as-is, so a multibyte one is 3 bytes per character:
+    // 603 bytes per entry means 13 fit (7839); counting characters would admit all 20.
+    var carrier = [String: String]()
+    let builder = DefaultBaggageBuilder()
+    for index in 0 ..< 20 {
+      builder.put(key: String(format: "k%02d", index), value: String(repeating: "\u{20AC}", count: 200))
+    }
+
+    jaegerPropagator.inject(baggage: builder.setNoParent().build(), carrier: &carrier, setter: setter)
+
+    XCTAssertEqual(carrier.keys.filter { $0.hasPrefix(JaegerBaggagePropagator.baggagePrefix) }.count, 13)
+  }
 }

--- a/Tests/OpenTelemetryApiTests/Baggage/Propagation/W3CBaggagePropagatorTest.swift
+++ b/Tests/OpenTelemetryApiTests/Baggage/Propagation/W3CBaggagePropagatorTest.swift
@@ -290,6 +290,47 @@ class W3BaggagePropagatorTest: XCTestCase {
     XCTAssertNil(result.getEntryValue(key: EntryKey(name: "k1")!))
   }
 
+  func testW3CInjectStopsAtMaxListMembers() {
+    var carrier = [String: String]()
+    for index in 0 ..< 65 {
+      builder.put(key: String(format: "k%02d", index), value: "v")
+    }
+
+    propagator.inject(baggage: builder.setNoParent().build(), carrier: &carrier, setter: setter)
+
+    let members = (carrier["baggage"] ?? "").split(separator: ",").map(String.init)
+    XCTAssertEqual(members.count, 64)
+    // Entries are sorted before the limit applies, so the same 64 are kept on every run.
+    XCTAssertEqual(members, (0 ..< 64).map { String(format: "k%02d=v", $0) })
+  }
+
+  func testW3CInjectStaysWithinMaxBytes() {
+    // Values are capped at 255 characters, so each member is 259 bytes and n of them cost
+    // 260n - 1. Thirty-one fit (8059); a thirty-second would be 8319.
+    var carrier = [String: String]()
+    for index in 0 ..< 40 {
+      builder.put(key: String(format: "k%02d", index), value: String(repeating: "v", count: 255))
+    }
+
+    propagator.inject(baggage: builder.setNoParent().build(), carrier: &carrier, setter: setter)
+
+    let header = carrier["baggage"] ?? ""
+    XCTAssertLessThanOrEqual(header.utf8.count, 8192)
+    XCTAssertEqual(header.split(separator: ",").count, 31)
+  }
+
+  func testW3CInjectCountsHeaderBytesNotCharacters() {
+    // Metadata is written through as-is, so a multibyte one is 3 bytes per character.
+    // 3000 characters are 9004 bytes with "k=v;" - over the limit - but only 3004 characters.
+    var carrier = [String: String]()
+    builder.put(key: "a", value: "b")
+    builder.put(key: "k", value: "v", metadata: String(repeating: "\u{20AC}", count: 3000))
+
+    propagator.inject(baggage: builder.setNoParent().build(), carrier: &carrier, setter: setter)
+
+    XCTAssertEqual(carrier["baggage"], "a=b")
+  }
+
   func testW3CNoListMemberFits() {
     let header = "k=v;" + String(repeating: "m", count: 9000)
 

--- a/Tests/OpenTelemetryApiTests/Baggage/Propagation/ZipkinBaggagePropagatorTests.swift
+++ b/Tests/OpenTelemetryApiTests/Baggage/Propagation/ZipkinBaggagePropagatorTests.swift
@@ -83,4 +83,46 @@ class ZipkinBaggagePropagatorTests: XCTestCase {
     let result = zipkinPropagator.extract(carrier: carrier, getter: getter)!
     XCTAssertEqual(result.getEntries().count, 31)
   }
+
+  func testInjectMaxEntries() {
+    var carrier = [String: String]()
+    let builder = DefaultBaggageBuilder()
+    for index in 0 ..< 65 {
+      builder.put(key: String(format: "k%02d", index), value: "v")
+    }
+
+    zipkinPropagator.inject(baggage: builder.setNoParent().build(), carrier: &carrier, setter: setter)
+
+    XCTAssertEqual(carrier.keys.filter { $0.hasPrefix(ZipkinBaggagePropagator.baggagePrefix) }.count, 64)
+    // Entries are sorted before the limit applies, so the same 64 are kept on every run.
+    XCTAssertNotNil(carrier[ZipkinBaggagePropagator.baggagePrefix + "k63"])
+    XCTAssertNil(carrier[ZipkinBaggagePropagator.baggagePrefix + "k64"])
+  }
+
+  func testInjectMaxBytes() {
+    // 32 entries of 260 bytes are 8320 bytes. 31 fit (8060), the 32nd does not.
+    var carrier = [String: String]()
+    let builder = DefaultBaggageBuilder()
+    for index in 0 ..< 32 {
+      builder.put(key: String(format: "key%07d", index), value: String(repeating: "v", count: 250))
+    }
+
+    zipkinPropagator.inject(baggage: builder.setNoParent().build(), carrier: &carrier, setter: setter)
+
+    XCTAssertEqual(carrier.keys.filter { $0.hasPrefix(ZipkinBaggagePropagator.baggagePrefix) }.count, 31)
+  }
+
+  func testInjectCountsBytesNotCharacters() {
+    // Values are written through as-is, so a multibyte one is 3 bytes per character:
+    // 603 bytes per entry means 13 fit (7839); counting characters would admit all 20.
+    var carrier = [String: String]()
+    let builder = DefaultBaggageBuilder()
+    for index in 0 ..< 20 {
+      builder.put(key: String(format: "k%02d", index), value: String(repeating: "\u{20AC}", count: 200))
+    }
+
+    zipkinPropagator.inject(baggage: builder.setNoParent().build(), carrier: &carrier, setter: setter)
+
+    XCTAssertEqual(carrier.keys.filter { $0.hasPrefix(ZipkinBaggagePropagator.baggagePrefix) }.count, 13)
+  }
 }


### PR DESCRIPTION
Fixes #108.

`W3CBaggagePropagator.inject`, `JaegerBaggagePropagator.inject` and `ZipkinBaggagePropagator.inject` write every entry of the baggage back out, however many there are and however long they are. #109 and #110 applied the limits on extract; the W3C Baggage spec (https://www.w3.org/TR/baggage/#limits) places them on propagation, so they apply to what a platform sends as well as to what it accepts, and when list-members are dropped none may be kept in part.

This applies the same 64 entries and 8192 bytes on inject. `W3CBaggagePropagator` counts for itself, because its output is one header whose separators count towards the 8192: a member is skipped when it and its comma would take the header past the limit, so the header written is never over budget and never holds a partial member. Jaeger and Zipkin write one carrier entry per baggage entry, so they reuse the counter their extract paths already share. Extract, the empty-baggage behavior and the 255-character caps in `EntryKey` and `EntryValue` are unchanged. This is a behavior change for a baggage past either limit, which was written out in full before.

`BaggageExtractLimits` is renamed `BaggagePropagationLimits`, since it now bounds both directions. The type is internal, so no public API changes.

opentelemetry-java applies both limits in `inject` as well, in its `W3CBaggagePropagator` and its Jaeger propagator; opentelemetry-ruby's W3C propagator has capped its encode path for years.

The baggage is a dictionary and Swift seeds its hasher per process, so without an order the entries dropped at capacity would differ from run to run and between peers in one trace. The entries are sorted before the limits apply, which the spec leaves to the implementer, so the same ones are kept everywhere.

Nine tests, three per propagator: 65 entries inject exactly the first 64 and the 65th is absent; 40 members of 259 bytes inject 31, since 31 with their separators are 8059 bytes and a 32nd would be 8319; 32 entries of 260 bytes inject 31; and the budget is counted in bytes rather than characters, exercised where text is written through unencoded — metadata for W3C, values for Jaeger and Zipkin — where a 200-character multibyte value is 603 bytes with its key, so 13 fit while counting characters would admit all 20. `swift test`: 632 tests, 0 failures on macOS (Xcode 26.6); the Linux and Apple-platform matrices were not run locally.

AI-assisted; reviewed and tested by me.
